### PR TITLE
lua expansion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4716,6 +4716,7 @@ dependencies = [
  "once_cell",
  "rfd",
  "rusqlite",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "shell-words",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,6 +4674,7 @@ dependencies = [
  "image 0.25.6",
  "itertools 0.14.0",
  "log",
+ "mlua",
  "parking_lot 0.12.4",
  "paste",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4717,6 +4717,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "shell-words",
  "spel-katalog-common",
  "spel-katalog-settings",
  "spel-katalog-terminal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ pretty_assertions = "1.4.1"
 prettyplease = "0.2.33"
 proc-macro2 = { version = "1.0.95", default-features = false }
 quote = { version = "1.0.40", default-features = false }
+rand = "0.9.2"
 ratatui = "0.29.0"
 rayon = "1.10.0"
 regex = "1.11.1"
@@ -87,8 +88,7 @@ thiserror = "2.0.12"
 tokio = { version = "1.45.1" }
 tokio-stream = { version = "0.1.17" }
 toml = "0.8.22"
+vte = "0.15.0"
 whoami = { version = "1.6.0", default-features = false }
 xdg = "3.0.0"
 yaml-rust2 = "0.10.3"
-vte = "0.15.0"
-rand = "0.9.2"

--- a/lua_api.md
+++ b/lua_api.md
@@ -16,14 +16,23 @@ Debug print and return all passed values.
 Print given string. Should be used for printing to make sure output is
 captured correctly.
 
-### `loadYaml(path: String)`
+## `getEnv(name: String) -> String | None`
+Read an environment variable.
+
+### `loadYaml(path: String) -> Value`
 Load yaml at path into a lua value.
+
+### `loadFile(path: String) -> String`
+Load contents of a file to memory.
 
 ### `loadCover(slug: String) -> Image | None`
 Load a cover thumbnail from thumbnail cache.
 
 ### `loadImage(path: String) -> Image | None`
 Load an image from given path.
+
+### `saveFile(path: String, content: String)`
+Save content to given path.
 
 ### `Image:w()`
 Get image width.

--- a/lua_api.md
+++ b/lua_api.md
@@ -2,8 +2,11 @@
 
 ## Types
 
-## `Image`
+### `Image`
 Loaded image, has functions as defined bellow functions header.
+
+### `Command`
+An external command to be executed.
 
 ## Functions
 Functions are provided by the `"@spel-katalog"` module which has
@@ -45,6 +48,9 @@ Save image to given path.
 
 ### `Image:saveCover(slug: String)`
 Save image as cover for given slug.
+
+### `Command::status() -> Int | None`
+Run the command returning the exit code if not interrupted.
 
 ## Values
 

--- a/lua_api.md
+++ b/lua_api.md
@@ -63,6 +63,9 @@ Load an image from given path.
 ### `saveFile(path: String, content: String)`
 Save content to given path.
 
+### `pathExists(path: String) -> bool`
+Check if the given path exists.
+
 ### `Image:w() -> Int`
 Get image width.
 

--- a/lua_api.md
+++ b/lua_api.md
@@ -78,6 +78,10 @@ Save image as cover for given slug.
 ### `Command:status() -> Int | None`
 Run the command returning the exit code if not interrupted.
 
+### `Command:splitExec() -> Command`
+Create a new command with the current binary split ny shell splitting
+rules as new binary and initial arguments.
+
 ### `Command:output(input: String..) -> Output`
 Run the command with the given optional input (given to command separated by newlines),
 returning a table with exit status, stderr and stdout.

--- a/lua_api.md
+++ b/lua_api.md
@@ -97,3 +97,8 @@ Current settings as a table. Provided as a member of the module.
 
 ### `data`
 Batch data, provided as a table/vector in global scope.
+Only available when running batch scripts.
+
+### `game`
+Data for a single game, same format as values of batch data.
+Only available when running as a pre-launch script.

--- a/lua_api.md
+++ b/lua_api.md
@@ -16,7 +16,7 @@ Debug print and return all passed values.
 Print given string. Should be used for printing to make sure output is
 captured correctly.
 
-## `getEnv(name: String) -> String | None`
+### `getEnv(name: String) -> String | None`
 Read an environment variable.
 
 ### `loadYaml(path: String) -> Value`

--- a/lua_api.md
+++ b/lua_api.md
@@ -8,6 +8,10 @@ Loaded image, has functions as defined bellow functions header.
 ### `Command`
 An external command to be executed.
 
+### `Output`
+A table which is the result of `Command:output` being called.
+Has three fields `status: Int | None`, `stdout: String` and `Stderr: String`.
+
 ## Functions
 Functions are provided by the `"@spel-katalog"` module which has
 to be required (`require'@spel-katalog'`).
@@ -49,8 +53,12 @@ Save image to given path.
 ### `Image:saveCover(slug: String)`
 Save image as cover for given slug.
 
-### `Command::status() -> Int | None`
+### `Command:status() -> Int | None`
 Run the command returning the exit code if not interrupted.
+
+### `Command:output(input: String..) -> Output`
+Run the command with the given optional input (given to command separated by newlines),
+returning a table with exit status, stderr and stdout.
 
 ## Values
 

--- a/lua_api.md
+++ b/lua_api.md
@@ -1,5 +1,24 @@
 # Lua API for batch scripts
 
+## Conventions
+This file is written following some conventions for describing the types
+used by functions.
+
+In these examples `Ty`, optionally followed by a number, may be any type.
+
+### `Any`
+May be any lua type.
+
+### `Ty..`
+A variadic input to a function with the given type.
+
+### `[Ty]`
+An array, a table of numbered entries from 1 upwards mapping to values
+of `Ty`.
+
+### `Ty1 | Ty2`
+Either `Ty1` or `Ty2` 
+
 ## Types
 
 ### `Image`
@@ -26,6 +45,9 @@ captured correctly.
 ### `getEnv(name: String) -> String | None`
 Read an environment variable.
 
+### `shellSplit(arg: String..) -> [String]`
+Split the given input/s using shell splitting rules.
+
 ### `loadYaml(path: String) -> Value`
 Load yaml at path into a lua value.
 
@@ -41,10 +63,10 @@ Load an image from given path.
 ### `saveFile(path: String, content: String)`
 Save content to given path.
 
-### `Image:w()`
+### `Image:w() -> Int`
 Get image width.
 
-### `Image:h()`
+### `Image:h() -> Int`
 Get image height.
 
 ### `Image:save(path: String)`

--- a/spel-katalog-batch/Cargo.toml
+++ b/spel-katalog-batch/Cargo.toml
@@ -17,6 +17,7 @@ rfd = { workspace = true, features = ["xdg-portal","tokio"] }
 rusqlite.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+shell-words.workspace = true
 spel-katalog-common.workspace = true
 spel-katalog-settings.workspace = true
 spel-katalog-terminal.workspace = true

--- a/spel-katalog-batch/Cargo.toml
+++ b/spel-katalog-batch/Cargo.toml
@@ -10,11 +10,13 @@ workspace = true
 derive_more = { workspace = true, features = ["display"] }
 iced.workspace = true
 iced_highlighter.workspace = true
+image.workspace = true
 log.workspace = true
 mlua = { workspace = true, features = ["serde", "luau", "luau-jit", "vendored"]}
 once_cell.workspace = true
 rfd = { workspace = true, features = ["xdg-portal","tokio"] }
 rusqlite.workspace = true
+rustc-hash.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 shell-words.workspace = true
@@ -25,4 +27,3 @@ strum = { workspace = true, features = ["derive"] }
 tap.workspace = true
 tokio = { workspace = true, features = ["process"] }
 yaml-rust2.workspace = true
-image.workspace = true

--- a/spel-katalog-batch/src/lib.rs
+++ b/spel-katalog-batch/src/lib.rs
@@ -1,6 +1,7 @@
 //! Batch command runner.
 
 use ::std::{
+    collections::HashMap,
     io::{Write, pipe},
     process::Command,
     sync::Arc,
@@ -19,6 +20,7 @@ use ::iced::{
     },
 };
 use ::iced_highlighter::Highlighter;
+use ::rustc_hash::FxHashMap;
 use ::serde::Serialize;
 use ::spel_katalog_common::{OrRequest, StatusSender, async_status};
 use ::spel_katalog_terminal::{SinkBuilder, SinkIdentity};
@@ -42,6 +44,8 @@ pub struct BatchInfo {
     pub config: String,
     /// True if the game is hidden.
     pub hidden: bool,
+    /// Custom attributes set for game.
+    pub attrs: FxHashMap<String, String>,
 }
 
 /// Message for batch view.
@@ -431,6 +435,7 @@ impl State {
                                         runner: "wine".to_owned(),
                                         config: "/dev/null".to_owned(),
                                         hidden: false,
+                                        attrs: HashMap::default(),
                                     })
                                     .collect::<Vec<_>>()
                                     .pipe(Message::RunBatch)

--- a/spel-katalog-batch/src/lib.rs
+++ b/spel-katalog-batch/src/lib.rs
@@ -25,7 +25,7 @@ use ::spel_katalog_terminal::{SinkBuilder, SinkIdentity};
 use ::strum::VariantArray;
 use ::tap::Pipe;
 
-mod lua_api;
+pub mod lua_api;
 
 /// One entry to be sent to batch script.
 #[derive(Debug, Clone, Default, Serialize)]

--- a/spel-katalog-batch/src/lua_api.rs
+++ b/spel-katalog-batch/src/lua_api.rs
@@ -13,10 +13,10 @@ use ::spel_katalog_terminal::{SinkBuilder, SinkIdentity};
 
 use crate::BatchInfo;
 
+mod cmd;
 mod fs;
 mod image;
 mod print;
-mod cmd;
 
 fn to_runtime<D: Display>(d: D) -> ::mlua::Error {
     ::mlua::Error::runtime(d)

--- a/spel-katalog-batch/src/lua_api.rs
+++ b/spel-katalog-batch/src/lua_api.rs
@@ -1,192 +1,30 @@
 use ::std::{
     ffi::OsStr,
     fmt::Display,
-    io::{Cursor, PipeWriter, Write},
     os::unix::ffi::OsStrExt,
     path::{Path, PathBuf},
     rc::Rc,
 };
 
-use ::image::{DynamicImage, ImageFormat::Png, ImageReader};
-use ::mlua::{IntoLua, Lua, UserDataMethods};
+use ::mlua::Lua;
 use ::once_cell::unsync::OnceCell;
-use ::rusqlite::{Connection, OptionalExtension, params};
 use ::serde::Serialize;
-use ::spel_katalog_terminal::{SinkBuilder, SinkIdentity};
-use ::yaml_rust2::{Yaml, YamlLoader};
+use ::spel_katalog_terminal::SinkBuilder;
 
 use crate::BatchInfo;
 
+mod fs;
+mod image;
+mod print;
+
 fn to_runtime<D: Display>(d: D) -> ::mlua::Error {
     ::mlua::Error::runtime(d)
-}
-
-fn lua_load_yaml(lua: &Lua, path: String) -> ::mlua::Result<::mlua::Value> {
-    let yml = YamlLoader::load_from_str(
-        &::std::fs::read_to_string(&path).map_err(::mlua::Error::runtime)?,
-    )
-    .map_err(::mlua::Error::runtime)?
-    .into_iter()
-    .next()
-    .ok_or_else(|| ::mlua::Error::runtime("no yaml was loaded"))?;
-
-    fn conv(lua: &Lua, yml: Yaml) -> ::mlua::Result<::mlua::Value> {
-        match yml {
-            Yaml::Real(r) => r
-                .parse::<f64>()
-                .map_err(::mlua::Error::runtime)?
-                .into_lua(lua),
-            Yaml::Integer(i) => i.into_lua(lua),
-            Yaml::String(s) => s.into_lua(lua),
-            Yaml::Boolean(b) => b.into_lua(lua),
-            Yaml::Array(vec) => vec
-                .into_iter()
-                .try_fold(lua.create_table()?, |table, yaml| {
-                    table.push(conv(lua, yaml)?)?;
-                    Ok(table)
-                })
-                .map(::mlua::Value::Table),
-            Yaml::Hash(hash_map) => hash_map
-                .into_iter()
-                .try_fold(lua.create_table()?, |table, (key, value)| {
-                    let key = conv(lua, key)?;
-                    let value = conv(lua, value)?;
-                    table.set(key, value)?;
-                    Ok(table)
-                })
-                .map(::mlua::Value::Table),
-            Yaml::Null | Yaml::BadValue | Yaml::Alias(_) => Ok(::mlua::Value::NULL),
-        }
-    }
-
-    conv(lua, yml)
-}
-
-fn lua_print(_: &Lua, value: String, w: Option<&mut PipeWriter>) -> ::mlua::Result<()> {
-    if let Some(w) = w {
-        writeln!(w, "{value}")?;
-    } else {
-        println!("{value}");
-    }
-    ::log::info!("printed {value}");
-    Ok(())
-}
-
-fn lua_dbg(
-    _: &Lua,
-    mv: ::mlua::MultiValue,
-    w: Option<&mut PipeWriter>,
-) -> ::mlua::Result<::mlua::MultiValue> {
-    if let Some(w) = w {
-        for value in &mv {
-            writeln!(w, "{value:#?}")?;
-        }
-    } else {
-        for value in &mv {
-            println!("{value:#?}");
-        }
-    }
-    Ok(mv)
-}
-
-fn get_conn<'c>(
-    conn: &'c OnceCell<::rusqlite::Connection>,
-    db_path: &Path,
-) -> ::mlua::Result<&'c ::rusqlite::Connection> {
-    conn.get_or_try_init(|| ::rusqlite::Connection::open(db_path))
-        .map_err(::mlua::Error::runtime)
-}
-
-fn lua_load_cover(
-    lua: &Lua,
-    slug: String,
-    db_path: &Path,
-    conn: &OnceCell<::rusqlite::Connection>,
-) -> ::mlua::Result<::mlua::Value> {
-    get_conn(conn, db_path)?
-        .prepare_cached(r"SELECT image FROM images WHERE slug = ?1")
-        .map_err(to_runtime)?
-        .query_one(params![slug], |row| row.get::<_, Vec<u8>>(0))
-        .optional()
-        .map_err(to_runtime)?
-        .map(|image| ::image::load_from_memory_with_format(&image, Png))
-        .transpose()
-        .map_err(to_runtime)?
-        .map(|image| lua.create_any_userdata(image))
-        .transpose()
-        .map(|data| data.map_or_else(|| ::mlua::Value::NULL, ::mlua::Value::UserData))
-}
-
-fn lua_load_image(lua: &Lua, path: ::mlua::String) -> ::mlua::Result<::mlua::Value> {
-    fn ld(path: &Path) -> Result<DynamicImage, ()> {
-        ImageReader::open(path)
-            .map_err(|err| ::log::error!("could not open image {path:?}\n{err}"))?
-            .decode()
-            .map_err(|err| ::log::error!("could not decode image {path:?}\n{err}"))
-    }
-    ld(Path::new(OsStr::from_bytes(&path.as_bytes())))
-        .ok()
-        .map_or_else(
-            || Ok(::mlua::Value::NULL),
-            |img| lua.create_any_userdata(img).map(::mlua::Value::UserData),
-        )
 }
 
 fn lua_get_env(lua: &Lua, name: ::mlua::String) -> ::mlua::Result<Option<::mlua::String>> {
     ::std::env::var_os(OsStr::from_bytes(&name.as_bytes()))
         .map(|value| lua.create_string(value.as_bytes()))
         .transpose()
-}
-
-fn lua_load_file(lua: &Lua, path: ::mlua::String) -> ::mlua::Result<::mlua::String> {
-    let path = path.as_bytes();
-    let path = OsStr::from_bytes(&path);
-
-    let content = ::std::fs::read(path)?;
-    lua.create_string(content)
-}
-
-fn lua_save_file(
-    _lua: &Lua,
-    (path, content): (::mlua::String, ::mlua::String),
-) -> ::mlua::Result<()> {
-    let path = path.as_bytes();
-    let path = OsStr::from_bytes(&path);
-    let content = content.as_bytes();
-
-    ::std::fs::write(path, content)?;
-
-    Ok(())
-}
-
-pub fn register_image(
-    lua: &Lua,
-    conn: Rc<OnceCell<Connection>>,
-    db_path: Rc<Path>,
-) -> ::mlua::Result<()> {
-    lua.register_userdata_type::<DynamicImage>(move |r| {
-        r.add_method("w", |_, this, _: ()| Ok(this.width()));
-        r.add_method("h", |_, this, _: ()| Ok(this.height()));
-        r.add_method("save", |_, this, path: String| {
-            this.save(&path).map_err(to_runtime)
-        });
-        r.add_method("saveCover", move |_, this, slug: String| {
-            let conn = get_conn(&conn, &db_path)?;
-
-            let mut stmt = conn
-                .prepare_cached(r"INSERT INTO images (slug, image) VALUES (?1, ?2)")
-                .map_err(to_runtime)?;
-
-            let mut buf = Vec::<u8>::new();
-            this.write_to(&mut Cursor::new(&mut buf), Png)
-                .map_err(to_runtime)?;
-
-            stmt.execute(params![slug, buf]).map_err(to_runtime)?;
-
-            Ok(())
-        });
-    })?;
-    Ok(())
 }
 
 pub fn lua_batch(
@@ -201,39 +39,21 @@ pub fn lua_batch(
     let data = data.serialize(ser())?;
     let settings = settings.serialize(ser())?;
 
-    let conn = Rc::new(OnceCell::new());
-    let thumb_db_path = Rc::<Path>::from(thumb_db_path);
-
-    register_image(&lua, conn.clone(), thumb_db_path.clone())?;
-
     let globals = lua.globals();
     globals.set("data", data)?;
     globals.set("None", ::mlua::Value::NULL)?;
 
-    let [mut stdout, mut stderr] = if let Some([stdout, stderr]) =
-        sink_builder.get_pipe_writer_double(|| SinkIdentity::StaticName("Lua Batch"))?
-    {
-        [Some(stdout), Some(stderr)]
-    } else {
-        [None, None]
-    };
-
-    let load_cover =
-        lua.create_function(move |lua, slug| lua_load_cover(lua, slug, &thumb_db_path, &conn))?;
-    let dbg = lua.create_function_mut(move |lua, value| lua_dbg(lua, value, stderr.as_mut()))?;
-    let prnt = lua.create_function_mut(move |lua, value| lua_print(lua, value, stdout.as_mut()))?;
+    let conn = Rc::new(OnceCell::new());
+    let thumb_db_path = Rc::<Path>::from(thumb_db_path);
 
     let module = lua.create_table()?;
-    module.set("settings", settings)?;
 
-    module.set("loadYaml", lua.create_function(lua_load_yaml)?)?;
-    module.set("dbg", dbg)?;
-    module.set("print", prnt)?;
-    module.set("loadCover", load_cover)?;
-    module.set("loadImage", lua.create_function(lua_load_image)?)?;
+    image::register_image(&lua, conn, thumb_db_path, &module)?;
+    fs::register_fs(&lua, &module)?;
+    print::register_print(&lua, &module, sink_builder)?;
+
+    module.set("settings", settings)?;
     module.set("getEnv", lua.create_function(lua_get_env)?)?;
-    module.set("loadFile", lua.create_function(lua_load_file)?)?;
-    module.set("saveFile", lua.create_function(lua_save_file)?)?;
 
     lua.register_module("@spel-katalog", module)?;
 

--- a/spel-katalog-batch/src/lua_api.rs
+++ b/spel-katalog-batch/src/lua_api.rs
@@ -39,6 +39,12 @@ fn lua_shell_split(_lua: &Lua, args: Variadic<String>) -> ::mlua::Result<Vec<Str
     Ok(out)
 }
 
+fn lua_path_exists(_lua: &Lua, path: ::mlua::String) -> ::mlua::Result<bool> {
+    let path = path.as_bytes();
+    let path = Path::new(OsStr::from_bytes(&path));
+    Ok(path.exists())
+}
+
 fn serializer(lua: &Lua) -> ::mlua::serde::Serializer<'_> {
     ::mlua::serde::Serializer::new(lua)
 }
@@ -69,6 +75,7 @@ pub fn register_spel_katalog(
     module.set("settings", settings)?;
     module.set("getEnv", lua.create_function(lua_get_env)?)?;
     module.set("shellSplit", lua.create_function(lua_shell_split)?)?;
+    module.set("pathExists", lua.create_function(lua_path_exists)?)?;
 
     lua.register_module("@spel-katalog", module)?;
 

--- a/spel-katalog-batch/src/lua_api.rs
+++ b/spel-katalog-batch/src/lua_api.rs
@@ -1,3 +1,5 @@
+//! Lua api entrypoints.
+
 use ::std::{
     ffi::OsStr,
     fmt::Display,
@@ -41,6 +43,7 @@ fn serializer(lua: &Lua) -> ::mlua::serde::Serializer<'_> {
     ::mlua::serde::Serializer::new(lua)
 }
 
+/// Register `@spel-katalog` module with lua interpreter.
 pub fn register_spel_katalog(
     lua: &Lua,
     settings: ::spel_katalog_settings::Generic,
@@ -72,6 +75,7 @@ pub fn register_spel_katalog(
     Ok(())
 }
 
+/// Run a lua script with a batch.
 pub fn lua_batch(
     data: Vec<BatchInfo>,
     script: String,

--- a/spel-katalog-batch/src/lua_api/cmd.rs
+++ b/spel-katalog-batch/src/lua_api/cmd.rs
@@ -1,0 +1,63 @@
+use ::std::{
+    ffi::{OsStr, OsString},
+    os::unix::ffi::OsStrExt,
+    process,
+};
+
+use ::mlua::{Lua, Table, UserDataMethods, Variadic};
+use ::spel_katalog_terminal::{SinkBuilder, SinkIdentity};
+use ::tap::Pipe;
+
+#[derive(Debug, Clone)]
+struct Command {
+    exec: OsString,
+    args: Vec<OsString>,
+}
+
+impl Command {
+    fn new(
+        lua: &Lua,
+        exec: ::mlua::String,
+        args: Variadic<::mlua::String>,
+    ) -> ::mlua::Result<::mlua::Value> {
+        let cmd = Command {
+            exec: OsString::from(OsStr::from_bytes(&exec.as_bytes())),
+            args: args
+                .iter()
+                .map(|arg| OsString::from(OsStr::from_bytes(&arg.as_bytes())))
+                .collect(),
+        };
+
+        lua.create_any_userdata(cmd)?
+            .pipe(::mlua::Value::UserData)
+            .pipe(Ok)
+    }
+
+    fn status(&self, sink_builder: &SinkBuilder) -> ::mlua::Result<Option<i32>> {
+        let [stdout, stderr] =
+            sink_builder.build_double(|| SinkIdentity::StaticName("Lua Batch Cmd"))?;
+        Ok(process::Command::new(&self.exec)
+            .args(&self.args)
+            .stdout(stdout)
+            .stderr(stderr)
+            .status()?
+            .code())
+    }
+}
+
+pub fn register_cmd(lua: &Lua, module: &Table, sink_builder: &SinkBuilder) -> ::mlua::Result<()> {
+    let sink_builder = sink_builder.clone();
+
+    module.set(
+        "cmd",
+        lua.create_function(|lua, (exec, args)| Command::new(lua, exec, args))?,
+    )?;
+
+    lua.register_userdata_type::<Command>(move |r| {
+        r.add_method("status", move |_lua, this, _: ()| {
+            this.status(&sink_builder)
+        });
+    })?;
+
+    Ok(())
+}

--- a/spel-katalog-batch/src/lua_api/cmd.rs
+++ b/spel-katalog-batch/src/lua_api/cmd.rs
@@ -1,7 +1,8 @@
 use ::std::{
     ffi::{OsStr, OsString},
+    io::{Read, Write, pipe},
     os::unix::ffi::OsStrExt,
-    process,
+    process, thread,
 };
 
 use ::mlua::{Lua, Table, UserDataMethods, Variadic};
@@ -33,6 +34,81 @@ impl Command {
             .pipe(Ok)
     }
 
+    fn output(&self, lua: &Lua, input: Variadic<String>) -> ::mlua::Result<::mlua::Table> {
+        let mut input = input.into_iter();
+        let table = lua.create_table()?;
+
+        let (status, stdout, stderr) = if let Some(first) = input.next() {
+            let (stdin, mut w_stdin) = pipe()?;
+            let (mut r_stdout, stdout) = pipe()?;
+            let (mut r_stderr, stderr) = pipe()?;
+
+            let mut child = process::Command::new(&self.exec)
+                .args(&self.args)
+                .stdin(stdin)
+                .stdout(stdout)
+                .stderr(stderr)
+                .spawn()?;
+
+            let r = thread::scope(|s| -> ::std::io::Result<_> {
+                let stdout = s.spawn(move || -> ::std::io::Result<_> {
+                    let mut buf = Vec::new();
+                    r_stdout.read_to_end(&mut buf)?;
+                    Ok(buf)
+                });
+
+                let stderr = s.spawn(move || -> ::std::io::Result<_> {
+                    let mut buf = Vec::new();
+                    r_stderr.read_to_end(&mut buf)?;
+                    Ok(buf)
+                });
+
+                w_stdin.write_all(&first.as_bytes())?;
+
+                for s in input {
+                    w_stdin.write_all(b"\n")?;
+                    w_stdin.write_all(&s.as_bytes())?;
+                }
+
+                let status = child.wait()?;
+
+                let stdout = stdout
+                    .join()
+                    .unwrap_or_else(|p| ::std::panic::resume_unwind(p))?;
+
+                let stderr = stderr
+                    .join()
+                    .unwrap_or_else(|p| ::std::panic::resume_unwind(p))?;
+
+                Ok((status.code(), stdout, stderr))
+            });
+
+            match r {
+                Ok(value) => value,
+                Err(err) => {
+                    child.kill()?;
+                    return Err(err.into());
+                }
+            }
+        } else {
+            let process::Output {
+                status,
+                stdout,
+                stderr,
+            } = process::Command::new(&self.exec)
+                .args(&self.args)
+                .output()?;
+
+            (status.code(), stdout, stderr)
+        };
+
+        table.set("status", status)?;
+        table.set("stdout", lua.create_string(stdout)?)?;
+        table.set("stderr", lua.create_string(stderr)?)?;
+
+        Ok(table)
+    }
+
     fn status(&self, sink_builder: &SinkBuilder) -> ::mlua::Result<Option<i32>> {
         let [stdout, stderr] =
             sink_builder.build_double(|| SinkIdentity::StaticName("Lua Batch Cmd"))?;
@@ -57,6 +133,7 @@ pub fn register_cmd(lua: &Lua, module: &Table, sink_builder: &SinkBuilder) -> ::
         r.add_method("status", move |_lua, this, _: ()| {
             this.status(&sink_builder)
         });
+        r.add_method("output", |lua, this, input| this.output(lua, input));
     })?;
 
     Ok(())

--- a/spel-katalog-batch/src/lua_api/fs.rs
+++ b/spel-katalog-batch/src/lua_api/fs.rs
@@ -1,0 +1,92 @@
+//! Filesystem functions of lua api.
+
+use ::std::{ffi::OsStr, os::unix::ffi::OsStrExt, path::Path};
+
+use ::image::{DynamicImage, ImageReader};
+use ::mlua::{IntoLua, Lua, Table};
+use ::yaml_rust2::{Yaml, YamlLoader};
+
+fn lua_load_yaml(lua: &Lua, path: String) -> ::mlua::Result<::mlua::Value> {
+    let yml = YamlLoader::load_from_str(
+        &::std::fs::read_to_string(&path).map_err(::mlua::Error::runtime)?,
+    )
+    .map_err(::mlua::Error::runtime)?
+    .into_iter()
+    .next()
+    .ok_or_else(|| ::mlua::Error::runtime("no yaml was loaded"))?;
+
+    fn conv(lua: &Lua, yml: Yaml) -> ::mlua::Result<::mlua::Value> {
+        match yml {
+            Yaml::Real(r) => r
+                .parse::<f64>()
+                .map_err(::mlua::Error::runtime)?
+                .into_lua(lua),
+            Yaml::Integer(i) => i.into_lua(lua),
+            Yaml::String(s) => s.into_lua(lua),
+            Yaml::Boolean(b) => b.into_lua(lua),
+            Yaml::Array(vec) => vec
+                .into_iter()
+                .try_fold(lua.create_table()?, |table, yaml| {
+                    table.push(conv(lua, yaml)?)?;
+                    Ok(table)
+                })
+                .map(::mlua::Value::Table),
+            Yaml::Hash(hash_map) => hash_map
+                .into_iter()
+                .try_fold(lua.create_table()?, |table, (key, value)| {
+                    let key = conv(lua, key)?;
+                    let value = conv(lua, value)?;
+                    table.set(key, value)?;
+                    Ok(table)
+                })
+                .map(::mlua::Value::Table),
+            Yaml::Null | Yaml::BadValue | Yaml::Alias(_) => Ok(::mlua::Value::NULL),
+        }
+    }
+
+    conv(lua, yml)
+}
+
+fn lua_load_image(lua: &Lua, path: ::mlua::String) -> ::mlua::Result<::mlua::Value> {
+    fn ld(path: &Path) -> Result<DynamicImage, ()> {
+        ImageReader::open(path)
+            .map_err(|err| ::log::error!("could not open image {path:?}\n{err}"))?
+            .decode()
+            .map_err(|err| ::log::error!("could not decode image {path:?}\n{err}"))
+    }
+    ld(Path::new(OsStr::from_bytes(&path.as_bytes())))
+        .ok()
+        .map_or_else(
+            || Ok(::mlua::Value::NULL),
+            |img| lua.create_any_userdata(img).map(::mlua::Value::UserData),
+        )
+}
+
+fn lua_load_file(lua: &Lua, path: ::mlua::String) -> ::mlua::Result<::mlua::String> {
+    let path = path.as_bytes();
+    let path = OsStr::from_bytes(&path);
+
+    let content = ::std::fs::read(path)?;
+    lua.create_string(content)
+}
+
+fn lua_save_file(
+    _lua: &Lua,
+    (path, content): (::mlua::String, ::mlua::String),
+) -> ::mlua::Result<()> {
+    let path = path.as_bytes();
+    let path = OsStr::from_bytes(&path);
+    let content = content.as_bytes();
+
+    ::std::fs::write(path, content)?;
+
+    Ok(())
+}
+
+pub fn register_fs(lua: &Lua, module: &Table) -> ::mlua::Result<()> {
+    module.set("loadFile", lua.create_function(lua_load_file)?)?;
+    module.set("saveFile", lua.create_function(lua_save_file)?)?;
+    module.set("loadYaml", lua.create_function(lua_load_yaml)?)?;
+    module.set("loadImage", lua.create_function(lua_load_image)?)?;
+    Ok(())
+}

--- a/spel-katalog-batch/src/lua_api/image.rs
+++ b/spel-katalog-batch/src/lua_api/image.rs
@@ -1,0 +1,76 @@
+use ::std::{io::Cursor, path::Path, rc::Rc};
+
+use ::image::{DynamicImage, ImageFormat::Png};
+use ::mlua::{Lua, Table, UserDataMethods};
+use ::once_cell::unsync::OnceCell;
+use ::rusqlite::{Connection, OptionalExtension, params};
+
+use crate::lua_api::to_runtime;
+
+fn get_conn<'c>(
+    conn: &'c OnceCell<::rusqlite::Connection>,
+    db_path: &Path,
+) -> ::mlua::Result<&'c ::rusqlite::Connection> {
+    conn.get_or_try_init(|| ::rusqlite::Connection::open(db_path))
+        .map_err(::mlua::Error::runtime)
+}
+
+fn lua_load_cover(
+    lua: &Lua,
+    slug: String,
+    db_path: &Path,
+    conn: &OnceCell<::rusqlite::Connection>,
+) -> ::mlua::Result<::mlua::Value> {
+    get_conn(conn, db_path)?
+        .prepare_cached(r"SELECT image FROM images WHERE slug = ?1")
+        .map_err(to_runtime)?
+        .query_one(params![slug], |row| row.get::<_, Vec<u8>>(0))
+        .optional()
+        .map_err(to_runtime)?
+        .map(|image| ::image::load_from_memory_with_format(&image, Png))
+        .transpose()
+        .map_err(to_runtime)?
+        .map(|image| lua.create_any_userdata(image))
+        .transpose()
+        .map(|data| data.map_or_else(|| ::mlua::Value::NULL, ::mlua::Value::UserData))
+}
+
+pub fn register_image(
+    lua: &Lua,
+    conn: Rc<OnceCell<Connection>>,
+    db_path: Rc<Path>,
+    module: &Table,
+) -> ::mlua::Result<()> {
+    {
+        let db_path = db_path.clone();
+        let conn = conn.clone();
+        let load_cover =
+            lua.create_function(move |lua, slug| lua_load_cover(lua, slug, &db_path, &conn))?;
+
+        module.set("loadCover", load_cover)?;
+    }
+
+    lua.register_userdata_type::<DynamicImage>(move |r| {
+        r.add_method("w", |_, this, _: ()| Ok(this.width()));
+        r.add_method("h", |_, this, _: ()| Ok(this.height()));
+        r.add_method("save", |_, this, path: String| {
+            this.save(&path).map_err(to_runtime)
+        });
+        r.add_method("saveCover", move |_, this, slug: String| {
+            let conn = get_conn(&conn, &db_path)?;
+
+            let mut stmt = conn
+                .prepare_cached(r"INSERT INTO images (slug, image) VALUES (?1, ?2)")
+                .map_err(to_runtime)?;
+
+            let mut buf = Vec::<u8>::new();
+            this.write_to(&mut Cursor::new(&mut buf), Png)
+                .map_err(to_runtime)?;
+
+            stmt.execute(params![slug, buf]).map_err(to_runtime)?;
+
+            Ok(())
+        });
+    })?;
+    Ok(())
+}

--- a/spel-katalog-batch/src/lua_api/print.rs
+++ b/spel-katalog-batch/src/lua_api/print.rs
@@ -11,7 +11,6 @@ fn lua_print(_: &Lua, value: String, w: Option<&mut PipeWriter>) -> ::mlua::Resu
     } else {
         println!("{value}");
     }
-    ::log::info!("printed {value}");
     Ok(())
 }
 

--- a/spel-katalog-batch/src/lua_api/print.rs
+++ b/spel-katalog-batch/src/lua_api/print.rs
@@ -1,0 +1,50 @@
+//! debug and printing utilities.
+
+use ::std::io::{PipeWriter, Write};
+
+use ::mlua::{Lua, Table};
+use ::spel_katalog_terminal::{SinkBuilder, SinkIdentity};
+
+fn lua_print(_: &Lua, value: String, w: Option<&mut PipeWriter>) -> ::mlua::Result<()> {
+    if let Some(w) = w {
+        writeln!(w, "{value}")?;
+    } else {
+        println!("{value}");
+    }
+    ::log::info!("printed {value}");
+    Ok(())
+}
+
+fn lua_dbg(
+    _: &Lua,
+    mv: ::mlua::MultiValue,
+    w: Option<&mut PipeWriter>,
+) -> ::mlua::Result<::mlua::MultiValue> {
+    if let Some(w) = w {
+        for value in &mv {
+            writeln!(w, "{value:#?}")?;
+        }
+    } else {
+        for value in &mv {
+            println!("{value:#?}");
+        }
+    }
+    Ok(mv)
+}
+
+pub fn register_print(lua: &Lua, module: &Table, sink_builder: &SinkBuilder) -> ::mlua::Result<()> {
+    let [mut stdout, mut stderr] = if let Some([stdout, stderr]) =
+        sink_builder.get_pipe_writer_double(|| SinkIdentity::StaticName("Lua Batch"))?
+    {
+        [Some(stdout), Some(stderr)]
+    } else {
+        [None, None]
+    };
+
+    let dbg = lua.create_function_mut(move |lua, value| lua_dbg(lua, value, stderr.as_mut()))?;
+    let prnt = lua.create_function_mut(move |lua, value| lua_print(lua, value, stdout.as_mut()))?;
+
+    module.set("dbg", dbg)?;
+    module.set("print", prnt)?;
+    Ok(())
+}

--- a/spel-katalog/Cargo.toml
+++ b/spel-katalog/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 async-stream.workspace = true
 bon.workspace = true
 clap = { workspace = true, features = ["derive"] }
+clap_complete.workspace = true
 color-eyre.workspace = true
 derive_more = { workspace = true, features = ["from", "is_variant", "display", "into_iterator", "as_ref", "deref", "into", "deref_mut"] }
 env_logger.workspace = true
@@ -16,21 +17,23 @@ iced = { workspace = true, features = ["tokio", "lazy", "image", "advanced"] }
 image.workspace = true
 itertools.workspace = true
 log = { workspace = true, features = ["max_level_debug", "release_max_level_info"] }
+mlua = { workspace = true, features = ["serde"] }
 parking_lot.workspace = true
 paste.workspace = true
 rayon.workspace = true
 regex.workspace = true
 rfd = { workspace = true, features = ["xdg-portal","tokio"] }
 rustc-hash.workspace = true
+rustix = { workspace = true, features = ["process"] }
 serde = { workspace = true, features = ["derive"] }
 shell-words.workspace = true
 spel-katalog-batch.workspace = true
 spel-katalog-common.workspace = true
-spel-katalog-settings.workspace = true
 spel-katalog-games.workspace = true
 spel-katalog-info.workspace = true
-spel-katalog-script.workspace = true
 spel-katalog-parse.workspace = true
+spel-katalog-script.workspace = true
+spel-katalog-settings.workspace = true
 spel-katalog-terminal.workspace = true
 strsim.workspace = true
 tap.workspace = true
@@ -39,9 +42,7 @@ tokio = { workspace = true, features = ["parking_lot"] }
 tokio-stream = { workspace = true, features = ["time"] }
 toml.workspace = true
 xdg.workspace = true
-rustix = { workspace = true, features = ["process"] }
 yaml-rust2.workspace = true
-clap_complete.workspace = true
 
 [build-dependencies]
 spel-katalog-build.workspace = true

--- a/spel-katalog/src/exit_channel.rs
+++ b/spel-katalog/src/exit_channel.rs
@@ -1,0 +1,29 @@
+use ::iced::futures::channel::oneshot::{Canceled, Receiver, Sender};
+
+/// Sender for sending exit messages.
+#[derive(Debug)]
+pub struct ExitSender(Sender<()>);
+
+impl ExitSender {
+    pub fn send(self) {
+        let Self(sender) = self;
+        _ = sender.send(());
+    }
+}
+
+/// Receiver for exit messages.
+#[derive(Debug)]
+pub struct ExitReceiver(Receiver<()>);
+
+impl ExitReceiver {
+    pub(crate) async fn recv(self) -> Result<(), Canceled> {
+        let Self(recv) = self;
+        recv.await
+    }
+}
+
+/// Create a channel for sending exit messages.
+pub fn exit_channel() -> (ExitSender, ExitReceiver) {
+    let (tx, rx) = ::iced::futures::channel::oneshot::channel();
+    (ExitSender(tx), ExitReceiver(rx))
+}

--- a/spel-katalog/src/message.rs
+++ b/spel-katalog/src/message.rs
@@ -1,0 +1,42 @@
+use ::derive_more::{From, IsVariant};
+use ::spel_katalog_common::OrRequest;
+
+use crate::{Safety, process_info, view};
+
+#[derive(Debug, IsVariant, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum QuickMessage {
+    ClosePane,
+    CloseAll,
+    ToggleSettings,
+    OpenProcessInfo,
+    CycleHidden,
+    CycleFilter,
+    ToggleNetwork,
+    RefreshProcessInfo,
+    RunSelected,
+    Next,
+    Prev,
+    ToggleBatch,
+}
+
+#[derive(Debug, IsVariant, From, Clone)]
+pub enum Message {
+    #[from]
+    Status(String),
+    Filter(String),
+    #[from]
+    Settings(::spel_katalog_settings::Message),
+    #[from]
+    View(view::Message),
+    #[from]
+    Games(OrRequest<::spel_katalog_games::Message, ::spel_katalog_games::Request>),
+    #[from]
+    Info(OrRequest<::spel_katalog_info::Message, ::spel_katalog_info::Request>),
+    RunGame(i64, Safety),
+    #[from]
+    Quick(QuickMessage),
+    ProcessInfo(Option<Vec<process_info::ProcessInfo>>),
+    Kill(i64),
+    #[from]
+    Batch(OrRequest<::spel_katalog_batch::Message, ::spel_katalog_batch::Request>),
+}

--- a/spel-katalog/src/run_game.rs
+++ b/spel-katalog/src/run_game.rs
@@ -1,0 +1,298 @@
+use ::std::{
+    ffi::{OsStr, OsString},
+    mem,
+};
+
+use ::iced::{
+    Task,
+    futures::{TryStreamExt, stream::FuturesOrdered},
+};
+use ::spel_katalog_common::status;
+use ::spel_katalog_info::formats::{self, Additional};
+use ::spel_katalog_script::script_file::ScriptFile;
+use ::spel_katalog_settings::{
+    ExtraConfigDir, FirejailExe, LutrisExe, Network, ScriptConfigDir, YmlDir,
+};
+use ::spel_katalog_terminal::SinkIdentity;
+use ::tap::Pipe;
+
+use crate::{App, Message, QuickMessage, Safety};
+
+impl App {
+    pub fn run_game(&mut self, id: i64, safety: Safety, no_game: bool) -> Task<Message> {
+        let Some(game) = self.games.by_id(id) else {
+            status!(&self.sender, "could not run game with id {id}");
+            return Task::none();
+        };
+
+        let lutris = self.settings.get::<LutrisExe>().clone();
+        let firejail = self.settings.get::<FirejailExe>().clone();
+        let slug = game.slug.clone();
+        let name = game.name.clone();
+        let runner = game.runner.clone();
+        let hidden = game.hidden;
+        let is_net_disabled = self.settings.get::<Network>().is_disabled();
+        let sink_builder = self.sink_builder.clone();
+        let configpath = self
+            .settings
+            .get::<YmlDir>()
+            .as_path()
+            .join(&game.configpath)
+            .with_extension("yml");
+        let extra_config_path = self
+            .settings
+            .get::<ExtraConfigDir>()
+            .as_path()
+            .join(format!("{id}.toml"));
+        let script_dir = self.settings.get::<ScriptConfigDir>().to_path_buf();
+
+        let (send_open, recv_open) = ::tokio::sync::oneshot::channel();
+
+        let open_process_list = Task::future(async {
+            match recv_open.await {
+                Ok(_) => Some(Message::Quick(QuickMessage::OpenProcessInfo)),
+                Err(err) => {
+                    ::log::error!("could not receive open signel through oneshot\n{err}");
+                    None
+                }
+            }
+        })
+        .then(|msg| msg.map_or_else(Task::none, Task::done));
+
+        let task = Task::future(async move {
+            #[derive(Debug, ::thiserror::Error)]
+            enum ScriptGatherError {
+                /// Forwarded io error.
+                #[error(transparent)]
+                Io(#[from] ::std::io::Error),
+                /// Forwarded script run error.
+                #[error(transparent)]
+                Script(#[from] ::spel_katalog_script::Error),
+                /// Forwarded parse error.
+                #[error(transparent)]
+                ParseRead(#[from] ::spel_katalog_script::ReadError),
+                /// Forwarded string interpolation error.
+                #[error("while interpolating {1:?}\n{0}")]
+                Interpolate(
+                    #[source] ::spel_katalog_parse::InterpolationError<String>,
+                    String,
+                ),
+            }
+
+            #[derive(Debug, ::thiserror::Error)]
+            enum ConfigError {
+                #[error(transparent)]
+                Io(#[from] ::std::io::Error),
+                #[error(transparent)]
+                Scan(#[from] ::yaml_rust2::ScanError),
+            }
+
+            let config = async {
+                let config = ::tokio::fs::read_to_string(&configpath).await?;
+                let config = formats::Config::parse(&config)?;
+
+                Ok::<_, ConfigError>(config)
+            };
+
+            let config = match config.await {
+                Ok(config) => config,
+                Err(err) => {
+                    ::log::error!("while loading config {configpath:?}\n{err}");
+                    return format!("could not load config for game").into();
+                }
+            };
+
+            let extra_config = if extra_config_path.exists() {
+                let Some(content) = ::tokio::fs::read_to_string(&extra_config_path)
+                    .await
+                    .map_err(|err| ::log::error!("could not read {extra_config_path:?}\n{err}"))
+                    .ok()
+                else {
+                    return format!("could not read {extra_config_path:?}").into();
+                };
+                let Some(additional) = ::toml::from_str::<Additional>(&content)
+                    .map_err(|err| ::log::error!("could not parse {extra_config_path:?}\n{err}"))
+                    .ok()
+                else {
+                    return format!("could not parse {extra_config_path:?}").into();
+                };
+
+                Some(additional)
+            } else {
+                None
+            };
+
+            let scripts_result = async {
+                if !script_dir.exists() {
+                    ::log::info!("no script dir, skipping");
+                    return Ok(());
+                }
+
+                let mut scripts = Vec::new();
+                let mut stack = Vec::new();
+
+                stack.push(script_dir);
+
+                while let Some(dir) = stack.pop() {
+                    let mut dir = ::tokio::fs::read_dir(dir).await?;
+                    while let Some(entry) = dir.next_entry().await? {
+                        let ft = entry.file_type().await?;
+
+                        let path = entry.path();
+
+                        if ft.is_dir() {
+                            stack.push(path);
+                        } else if ft.is_file() {
+                            scripts.push(path);
+                        } else {
+                            ::log::warn!("non file or directory path in script dir, {path:?}")
+                        }
+                    }
+                }
+
+                scripts.sort_unstable();
+
+                let mut scripts = scripts
+                    .iter()
+                    .map(|path| ScriptFile::read(&path))
+                    .collect::<FuturesOrdered<_>>()
+                    .try_collect::<Vec<_>>()
+                    .await?;
+
+                for script in &mut scripts {
+                    let globals = mem::take(&mut script.global);
+                    script
+                        .visit_strings(|s| {
+                            *s = ::spel_katalog_parse::interpolate_string(s, |key| match key {
+                                "HOME" => Some(::spel_katalog_settings::HOME.to_string()),
+                                "ID" => Some(id.to_string()),
+                                "SLUG" => Some(slug.clone()),
+                                "NAME" => Some(name.clone()),
+                                "RUNNER" => Some(runner.to_string()),
+                                "HIDDEN" => Some(hidden.to_string()),
+                                "EXE" => Some(config.game.exe.display().to_string()),
+                                "PREFIX" => Some(config.game.prefix.as_ref().map_or_else(
+                                    || String::new(),
+                                    |pfx| pfx.display().to_string(),
+                                )),
+                                "ARCH" => Some(config.game.arch.clone().unwrap_or_default()),
+                                key => {
+                                    if let Some(global) = key.strip_prefix("GLOBAL.")
+                                        && let Some(value) = globals.get(global)
+                                    {
+                                        value.clone().pipe(Some)
+                                    } else if let Some(attr) = key.strip_prefix("ATTR.") {
+                                        extra_config
+                                            .as_ref()
+                                            .and_then(|extra_config| {
+                                                extra_config.attrs.get(attr).cloned()
+                                            })
+                                            .unwrap_or_default()
+                                            .pipe(Some)
+                                    } else {
+                                        None
+                                    }
+                                }
+                            })?;
+                            Ok(())
+                        })
+                        .map_err(|err| {
+                            ScriptGatherError::Interpolate(
+                                err,
+                                script.source.as_ref().map_or_else(
+                                    || script.id().to_owned(),
+                                    |source| source.display().to_string(),
+                                ),
+                            )
+                        })?;
+                }
+
+                ScriptFile::run_all(&scripts, &sink_builder).await?;
+                Ok::<_, ScriptGatherError>(())
+            };
+
+            if let Err(err) = scripts_result.await {
+                ::log::error!("failure when gathering/runnings scripts\n{err}");
+                return "running scripts failed".to_owned().into();
+            }
+
+            let rungame = if no_game {
+                None
+            } else {
+                Some(format!("lutris:rungameid/{id}"))
+            };
+
+            fn wl(p: impl AsRef<OsStr>) -> OsString {
+                let mut s = OsString::new();
+                s.push("--whitelist=");
+                s.push(p);
+                s
+            }
+
+            let (stdout, stderr) = match sink_builder.build_double(|| SinkIdentity::GameId(id)) {
+                Ok([stdout, stderr]) => (stdout, stderr),
+                Err(err) => {
+                    ::log::error!("could not create process output sinks\n{err}");
+                    return "could not create output sinks".to_owned().into();
+                }
+            };
+
+            let cmd = match safety {
+                Safety::None => {
+                    ::log::info!("executing {lutris:?} with arguments\n{:#?}", &[&rungame]);
+                    ::tokio::process::Command::new(lutris)
+                        .args(rungame)
+                        .kill_on_drop(true)
+                        .stdout(stdout)
+                        .stderr(stderr)
+                        .status()
+                }
+                Safety::Firejail => {
+                    let mut args = Vec::new();
+                    ::log::info!("parsed game config\n{config:#?}");
+                    if let Some(additional) = extra_config
+                        .map(|additional| additional.sandbox_root)
+                        .filter(|roots| !roots.is_empty())
+                    {
+                        args.extend(additional.into_iter().map(wl));
+                    } else {
+                        args.push(wl(config.game.common_parent()));
+                    }
+
+                    if is_net_disabled {
+                        args.push("--net=none".into());
+                    }
+
+                    args.push(lutris.as_os_str().into());
+
+                    if let Some(rungame) = rungame {
+                        args.push(rungame.into());
+                    };
+
+                    ::log::info!("executing {firejail:?} with arguments\n{args:#?}");
+
+                    ::tokio::process::Command::new(firejail)
+                        .args(args)
+                        .kill_on_drop(true)
+                        .stdout(stdout)
+                        .stderr(stderr)
+                        .status()
+                }
+            };
+
+            if send_open.send(()).is_err() {
+                ::log::warn!("could not send open signal through oneshot");
+            }
+
+            match cmd.await {
+                Ok(status) => format!("{name} exited with {status}").into(),
+                Err(err) => {
+                    ::log::error!("could not run {slug}\n{err}");
+                    format!("could not run {slug}").into()
+                }
+            }
+        });
+
+        Task::batch([task, open_process_list])
+    }
+}

--- a/spel-katalog/src/run_game.rs
+++ b/spel-katalog/src/run_game.rs
@@ -286,6 +286,10 @@ impl App {
                         name: name.clone(),
                         runner: runner.to_string(),
                         config: configpath.clone(),
+                        attrs: extra_config
+                            .as_ref()
+                            .map(|extra_config| extra_config.attrs.clone())
+                            .unwrap_or_default(),
                         hidden,
                     };
 

--- a/spel-katalog/src/subscription.rs
+++ b/spel-katalog/src/subscription.rs
@@ -1,0 +1,70 @@
+use ::std::time::Duration;
+
+use ::iced::{
+    Subscription,
+    keyboard::{self, Modifiers, key::Named, on_key_press},
+};
+use ::spel_katalog_common::OrRequest;
+use ::spel_katalog_games::SelDir;
+use ::tap::Pipe;
+
+use crate::{App, Message, QuickMessage};
+
+impl App {
+    pub fn subscription(&self) -> Subscription<Message> {
+        fn sel(sel_dir: SelDir) -> Option<Message> {
+            sel_dir
+                .pipe(::spel_katalog_games::Message::Select)
+                .pipe(OrRequest::Message)
+                .pipe(Message::Games)
+                .pipe(Some)
+        }
+        let on_key = on_key_press(|key, modifiers| match key.as_ref() {
+            keyboard::Key::Named(named) => match named {
+                Named::Tab if modifiers.is_empty() => Some(QuickMessage::Next).map(Message::Quick),
+                Named::Tab if modifiers == Modifiers::SHIFT => {
+                    Some(QuickMessage::Prev).map(Message::Quick)
+                }
+                Named::ArrowRight if modifiers.is_empty() => sel(SelDir::Right),
+                Named::ArrowLeft if modifiers.is_empty() => sel(SelDir::Left),
+                Named::ArrowUp if modifiers.is_empty() => sel(SelDir::Up),
+                Named::ArrowDown if modifiers.is_empty() => sel(SelDir::Down),
+                Named::Enter | Named::Space if modifiers.is_empty() => {
+                    Some(Message::Quick(QuickMessage::RunSelected))
+                }
+                _ => None,
+            },
+            keyboard::Key::Character(chr) => match chr {
+                "q" if modifiers.is_empty() => Some(QuickMessage::ClosePane),
+                "q" if modifiers == Modifiers::CTRL => Some(QuickMessage::CloseAll),
+                "h" if modifiers.is_empty() => Some(QuickMessage::CycleHidden),
+                "f" if modifiers.is_empty() => Some(QuickMessage::CycleFilter),
+                "s" if modifiers.is_empty() => Some(QuickMessage::ToggleSettings),
+                "n" if modifiers.is_empty() => Some(QuickMessage::ToggleNetwork),
+                "k" if modifiers == Modifiers::CTRL | Modifiers::SHIFT => {
+                    Some(QuickMessage::OpenProcessInfo)
+                }
+                "b" if modifiers == Modifiers::CTRL | Modifiers::SHIFT => {
+                    Some(QuickMessage::ToggleBatch)
+                }
+                _ => None,
+            }
+            .map(Message::Quick),
+            keyboard::Key::Unidentified => None,
+        });
+
+        let refresh = if self.process_list.is_some() {
+            Some(
+                ::iced::time::every(Duration::from_millis(500))
+                    .map(|_| Message::Quick(QuickMessage::RefreshProcessInfo)),
+            )
+        } else {
+            None
+        };
+
+        [Some(on_key), refresh]
+            .into_iter()
+            .flatten()
+            .pipe(Subscription::batch)
+    }
+}

--- a/spel-katalog/src/update.rs
+++ b/spel-katalog/src/update.rs
@@ -1,0 +1,276 @@
+use ::std::convert::identity;
+
+use ::iced::{
+    Task,
+    widget::{self},
+};
+use ::rustix::process::{Pid, RawPid};
+use ::spel_katalog_batch::BatchInfo;
+use ::spel_katalog_common::OrRequest;
+use ::spel_katalog_games::SelDir;
+use ::spel_katalog_settings::{CoverartDir, FilterMode, Network, Show, Variants, YmlDir};
+use ::tap::Pipe;
+
+use crate::{App, Message, QuickMessage, Safety};
+
+impl App {
+    pub fn update(&mut self, msg: Message) -> Task<Message> {
+        match msg {
+            Message::Status(status) => {
+                self.set_status(status);
+                return Task::none();
+            }
+            Message::Filter(filter) => {
+                self.filter = filter;
+                self.games.sort(&self.settings, &self.filter);
+            }
+            Message::Settings(message) => {
+                let re_sort = matches!(
+                    &message,
+                    ::spel_katalog_settings::Message::Delta(
+                        ::spel_katalog_settings::Delta::FilterMode(..)
+                            | ::spel_katalog_settings::Delta::Show(..)
+                            | ::spel_katalog_settings::Delta::SortBy(..)
+                            | ::spel_katalog_settings::Delta::SortDir(..)
+                    )
+                );
+
+                let task = self.settings.update(message, &self.sender);
+
+                if re_sort {
+                    self.sort_games();
+                }
+
+                return task.map(From::from);
+            }
+            Message::View(message) => return self.view.update(message),
+            Message::Games(message) => {
+                let request = match message {
+                    OrRequest::Message(message) => {
+                        return self
+                            .games
+                            .update(message, &self.sender, &self.settings, &self.filter)
+                            .map(Message::Games);
+                    }
+                    OrRequest::Request(request) => request,
+                };
+                match request {
+                    ::spel_katalog_games::Request::SetId { id } => {
+                        return self
+                            .info
+                            .update(
+                                ::spel_katalog_info::Message::SetId { id },
+                                &self.sender,
+                                &self.settings,
+                                &self.games,
+                            )
+                            .map(Message::Info);
+                    }
+                    ::spel_katalog_games::Request::Run { id, sandbox } => {
+                        return self.run_game(
+                            id,
+                            if sandbox {
+                                Safety::Firejail
+                            } else {
+                                Safety::None
+                            },
+                            false,
+                        );
+                    }
+                    ::spel_katalog_games::Request::FindImages { slugs } => {
+                        return self
+                            .image_buffer
+                            .find_images(slugs, self.settings.get::<CoverartDir>().to_path_buf())
+                            .map(OrRequest::Message)
+                            .map(Message::Games);
+                    }
+                    ::spel_katalog_games::Request::CloseInfo => {
+                        self.view.show_info(false);
+                        self.games.select(SelDir::None);
+                    }
+                }
+            }
+            Message::Info(message) => {
+                let request = match message {
+                    OrRequest::Message(message) => {
+                        return self
+                            .info
+                            .update(message, &self.sender, &self.settings, &self.games)
+                            .map(Message::Info);
+                    }
+                    OrRequest::Request(request) => request,
+                };
+                match request {
+                    ::spel_katalog_info::Request::ShowInfo(show) => {
+                        self.view.show_info(show);
+                    }
+                    ::spel_katalog_info::Request::SetImage { slug, image } => {
+                        return self
+                            .games
+                            .update(
+                                ::spel_katalog_games::Message::SetImage { slug, image },
+                                &self.sender,
+                                &self.settings,
+                                &self.filter,
+                            )
+                            .map(Message::Games);
+                    }
+                    ::spel_katalog_info::Request::RunGame { id, sandbox } => {
+                        return self.run_game(id, Safety::from(sandbox), false);
+                    }
+                    ::spel_katalog_info::Request::RunLutrisInSandbox { id } => {
+                        return self.run_game(id, Safety::Firejail, true);
+                    }
+                }
+            }
+            Message::RunGame(id, safety) => return self.run_game(id, safety, false),
+            Message::Quick(quick) => match quick {
+                QuickMessage::CloseAll => {
+                    self.process_list = None;
+                    self.view.show_info(false);
+                    self.view.show_settings(false);
+                    self.games.select(SelDir::None);
+                    self.filter = String::new();
+                    self.sort_games();
+                }
+                QuickMessage::ClosePane => {
+                    if self.process_list.is_some() {
+                        self.process_list = None;
+                        self.set_status("closed process list");
+                    } else if self.view.info_shown() {
+                        self.view.show_info(false);
+                        self.set_status("closed info pane");
+                    } else if self.view.settings_shown() {
+                        self.view.show_settings(false);
+                        self.set_status("closed settings pane");
+                    } else if self.games.selected().is_some() {
+                        self.games.select(SelDir::None);
+                    } else if !self.filter.is_empty() {
+                        self.filter = String::new();
+                        self.sort_games();
+                    }
+                }
+                QuickMessage::ToggleSettings => {
+                    self.view.show_settings(!self.view.settings_shown());
+                }
+                QuickMessage::OpenProcessInfo => {
+                    return Task::future(Self::collect_process_info()).then(identity);
+                }
+                QuickMessage::CycleHidden => {
+                    let next = self.settings.get::<Show>().cycle();
+                    self.settings.apply_from(next);
+                    self.set_status(format!("cycled hidden to {next}"));
+                    self.sort_games();
+                }
+                QuickMessage::CycleFilter => {
+                    let next = self.settings.get::<FilterMode>().cycle();
+                    self.settings.apply_from(next);
+                    self.set_status(format!("cycled filter mode to {next}"));
+                    self.sort_games();
+                }
+                QuickMessage::ToggleNetwork => {
+                    let next = self.settings.get::<Network>().cycle();
+                    self.settings.apply_from(next);
+                    self.set_status(format!("toggled network to {next}"));
+                    self.sort_games();
+                }
+                QuickMessage::RefreshProcessInfo => {
+                    if self.process_list.is_some() {
+                        return Task::future(Self::collect_process_info()).then(identity);
+                    }
+                }
+                QuickMessage::Next => return widget::focus_next(),
+                QuickMessage::Prev => return widget::focus_previous(),
+                QuickMessage::RunSelected => {
+                    if let Some(id) = self.games.selected() {
+                        return self.run_game(id, Safety::Firejail, false);
+                    }
+                }
+                QuickMessage::ToggleBatch => self.show_batch = !self.show_batch,
+            },
+            Message::ProcessInfo(process_infos) => {
+                self.process_list = process_infos.filter(|infos| !infos.is_empty())
+            }
+            Message::Kill(pid) => {
+                let Ok(pid) = RawPid::try_from(pid) else {
+                    return Task::none();
+                };
+                let Some(pid) = Pid::from_raw(pid) else {
+                    return Task::none();
+                };
+
+                return Task::future(async move {
+                    match ::tokio::task::spawn_blocking(move || {
+                        ::rustix::process::kill_process(pid, ::rustix::process::Signal::TERM)
+                    })
+                    .await
+                    {
+                        Ok(result) => match result {
+                            Ok(_) => ::log::info!(
+                                "sent TERM to process {pid}",
+                                pid = pid.as_raw_nonzero().get()
+                            ),
+                            Err(err) => ::log::error!(
+                                "could not kill process {pid}\n{err}",
+                                pid = pid.as_raw_nonzero().get()
+                            ),
+                        },
+                        Err(err) => ::log::error!("could not spawn blocking thread\n{err}"),
+                    };
+                })
+                .then(|_| Task::none());
+            }
+            Message::Batch(or_request) => match or_request {
+                OrRequest::Message(msg) => {
+                    return self
+                        .batch
+                        .update(msg, &self.sender, &self.settings, &self.sink_builder)
+                        .map(From::from);
+                }
+                OrRequest::Request(req) => match req {
+                    ::spel_katalog_batch::Request::ShowProcesses => {
+                        return Task::done(Message::Quick(QuickMessage::OpenProcessInfo));
+                    }
+                    ::spel_katalog_batch::Request::HideBatch => self.show_batch = false,
+                    ::spel_katalog_batch::Request::GatherBatchInfo(scope) => {
+                        fn gather<'a>(
+                            yml_dir: &str,
+                            games: impl IntoIterator<Item = &'a ::spel_katalog_games::Game>,
+                        ) -> Task<Message> {
+                            games
+                                .into_iter()
+                                .map(|game| BatchInfo {
+                                    id: game.id,
+                                    slug: game.slug.clone(),
+                                    name: game.name.clone(),
+                                    runner: game.runner.to_string(),
+                                    config: format!("{yml_dir}/{}.yml", game.configpath),
+                                    hidden: game.hidden,
+                                })
+                                .collect::<Vec<_>>()
+                                .pipe(::spel_katalog_batch::Message::RunBatch)
+                                .pipe(OrRequest::Message)
+                                .pipe(Message::Batch)
+                                .pipe(Task::done)
+                        }
+                        let yml_dir = self.settings.get::<YmlDir>();
+                        let yml_dir = yml_dir.as_str();
+                        return match scope {
+                            ::spel_katalog_batch::Scope::All => gather(yml_dir, self.games.all()),
+                            ::spel_katalog_batch::Scope::Shown => {
+                                gather(yml_dir, self.games.displayed())
+                            }
+                            ::spel_katalog_batch::Scope::Batch => {
+                                gather(yml_dir, self.games.batch_selected())
+                            }
+                        };
+                    }
+                    ::spel_katalog_batch::Request::ReloadCache => {
+                        return self.games.find_cached(&self.settings).map(Message::Games);
+                    }
+                },
+            },
+        }
+        Task::none()
+    }
+}


### PR DESCRIPTION
- **in spel-katalog-batch, moved image registration to dedicated function**
- **in spel-katalog-batch, added lua functions to save and load files**
- **fix title of section**
- **in spel-katalog-batch, split up lua api across multiple rust modules**
- **in spel-katalog-batch, added command api**
- **in spel-katalog-batch, added output to command api**
- **in spel-katalog-batch, added shellSplit lua function**
- **in spel-katalog-batch, added splitExec to command api**
- **in spel-katalog-batch, split out module registration from batch running**
- **in spel-katalog, split up App impl**
- **in spel-katalog, some cleanup in run_game**
- **in spel-katalog, lua scripts are now found (not executed yet)**
- **in spel-katalog, spel-katalog-batch, added functionality to run lua scripts before game launch**
- **in spel-katalog, spel-katalog-batch, attrs are now available for batch and pre-launch scripts**
- **in spel-katalog-batch, added function to check if a path exists**
