### PR TITLE
tui enhancements

### DIFF
--- a/spel-katalog-terminal/src/lib.rs
+++ b/spel-katalog-terminal/src/lib.rs
@@ -69,13 +69,13 @@ impl Debug for Channels {
 }
 
 /// Run tui.
-pub fn tui(channels: Channels) -> ::std::io::Result<()> {
+pub fn tui(channels: Channels, keep_terminal: bool) -> ::std::io::Result<()> {
     ::ratatui::crossterm::execute!(
         ::std::io::stdout(),
         ::ratatui::crossterm::event::EnableMouseCapture
     )?;
     let mut terminal = ::ratatui::init();
-    let res = tui::tui(channels, &mut terminal);
+    let res = tui::tui(channels, &mut terminal, keep_terminal);
     ::ratatui::restore();
     _ = ::ratatui::crossterm::execute!(
         ::std::io::stdout(),

--- a/spel-katalog/src/lib.rs
+++ b/spel-katalog/src/lib.rs
@@ -58,8 +58,12 @@ pub struct Cli {
     pub config: PathBuf,
 
     /// Advanced terminal output.
-    #[arg(long)]
+    #[arg(long, visible_alias = "at")]
     pub advanced_terminal: bool,
+
+    /// Keep terminal open.
+    #[arg(long, visible_alias = "kt")]
+    pub keep_terminal: bool,
 
     /// Perform an action other than opening gui.
     #[command(subcommand)]
@@ -136,6 +140,7 @@ impl App {
                 config,
                 action,
                 advanced_terminal: _,
+                keep_terminal: _,
             } = cli;
 
             fn read_settings(

--- a/spel-katalog/src/lib.rs
+++ b/spel-katalog/src/lib.rs
@@ -62,7 +62,7 @@ pub struct Cli {
     pub advanced_terminal: bool,
 
     /// Keep terminal open.
-    #[arg(long, visible_alias = "kt")]
+    #[arg(long, visible_alias = "kt", requires("advanced_terminal"))]
     pub keep_terminal: bool,
 
     /// Perform an action other than opening gui.

--- a/spel-katalog/src/main.rs
+++ b/spel-katalog/src/main.rs
@@ -32,15 +32,19 @@ fn main() -> ::color_eyre::Result<()> {
 
         let (pipe_tx, pipe_rx) = channel();
         let (exit_tx, exit_rx) = exit_channel();
+        let keep_terminal = cli.keep_terminal;
 
         let app_handle = ::std::thread::Builder::new()
             .name("spel-katalog-app".to_owned())
-            .spawn(|| {
-                ::spel_katalog_terminal::tui(Channels {
-                    exit_tx: Box::new(|| exit_tx.send()),
-                    pipe_rx,
-                    log_rx,
-                })
+            .spawn(move || {
+                ::spel_katalog_terminal::tui(
+                    Channels {
+                        exit_tx: Box::new(|| exit_tx.send()),
+                        pipe_rx,
+                        log_rx,
+                    },
+                    keep_terminal,
+                )
             })?;
 
         App::run(cli, SinkBuilder::CreatePipe(pipe_tx), Some(exit_rx))?;


### PR DESCRIPTION
- **in spel-katalog-terminal, output now requires alt to be held to change, tui may be force redrawn by pressing r and added a keep-terminal option which keeps the terminal open on exit**
- **in spel-katalog, keep-terminal now requires advanced-terminal**
