### PR TITLE
Implement Bubblewrap sandboxing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,7 +1201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3898,7 +3898,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5641,7 +5641,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4298,6 +4298,7 @@ dependencies = [
  "tap",
  "thiserror 2.0.18",
  "toml 1.0.6+spec-1.1.0",
+ "users",
  "yaml-rust2",
 ]
 
@@ -5093,6 +5094,15 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,3 +137,4 @@ vte = "0.15.0"
 whoami = { version = "2.1.1", default-features = false }
 yaml-rust2 = "0.11.0"
 mimalloc = "0.1.48"
+users = { version = "0.11.0", default-features = false }

--- a/lua/spel-katalog.lua
+++ b/lua/spel-katalog.lua
@@ -225,6 +225,7 @@ function GameData:setAttrs(attrs) end
 ---@field SortBy ("Id" | "Name" | "Slug")
 ---@field SortDir ("Forward" | "Reverse")
 ---@field Network ("Disabled" | "Enabled")
+---@field SandboxMode ("Firejail" | "Bubblewrap")
 ---@field LutrisExe string
 ---@field FirejailExe string
 ---@field CoverartDir string

--- a/spel-katalog-build/src/format.rs
+++ b/spel-katalog-build/src/format.rs
@@ -46,6 +46,11 @@ pub mod settings {
             /// Setting default path.
             path: String,
         },
+        /// Setting is a string.
+        String {
+            /// Setting default string.
+            string: String,
+        }
     }
 
     /// A Single setting.

--- a/spel-katalog-build/src/format.rs
+++ b/spel-katalog-build/src/format.rs
@@ -50,7 +50,7 @@ pub mod settings {
         String {
             /// Setting default string.
             string: String,
-        }
+        },
     }
 
     /// A Single setting.

--- a/spel-katalog-build/src/settings.rs
+++ b/spel-katalog-build/src/settings.rs
@@ -266,6 +266,108 @@ fn emit_path(setting: &Setting, name: &str, ident: &Ident, path: &str) -> Emit {
     }
 }
 
+/// create an [Emit] for a string setting.
+fn emit_string(setting: &Setting, name: &str, ident: &Ident, path: &str) -> Emit {
+    let title_body = title_expr(name, setting.title.as_deref());
+    let doc = doc_str(&setting.help);
+    let default_value = str_expr(path);
+
+    let ty = parse_quote! {
+        #[derive(
+            Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash,
+            ::serde::Serialize, ::serde::Deserialize
+        )]
+        #[doc = #doc]
+        #[serde(transparent)]
+        pub struct #ident(String);
+    };
+
+    let impls = item::file(
+        &mut [
+            parse_quote! {
+                impl #ident {
+                    #[doc = "Construct a new value from a string."]
+                    #[inline]
+                    pub const fn new(string: ::std::string::String) -> Self {
+                        Self(string)
+                    }
+
+                    #[doc = "Unwrap into inner string value."]
+                    #[inline]
+                    pub fn into_inner(self) -> ::std::string::String {
+                        let Self(string) = self;
+                        string
+                    }
+
+                    #[doc = "Get setting as a string slice."]
+                    #[inline]
+                    pub const fn as_str(&self) -> &str {
+                        self.0.as_str()
+                    }
+
+                    #[doc = "Get setting as an os string."]
+                    #[inline]
+                    pub fn as_os_str(&self) -> &::std::ffi::OsStr{
+                        ::std::ffi::OsStr::new(self.as_str())
+                    }
+                }
+            },
+            item::title(ident, &title_body),
+            item::help(ident, &str_expr(doc.trim_end_matches('.'))),
+            item::default_str(ident, &default_value),
+            item::default(
+                ident,
+                &quote! { Self(<Self as crate::DefaultStr>::default_str().into()) },
+            ),
+            item::display(ident, &quote! { f.write_str(self.as_str()) }),
+            item::deref(ident, &quote! { str }, &quote! { self.as_str() }),
+            item::as_ref(ident, &quote! { str }, &quote! { self.as_str() }),
+            item::as_ref(
+                ident,
+                &quote! { ::std::ffi::OsStr },
+                &quote! { self.as_os_str() },
+            ),
+            item::as_ref(
+                ident,
+                &quote! { ::std::string::String },
+                &quote! { &self.0 },
+            ),
+            item::as_mut(
+                ident,
+                &quote! { ::std::string::String },
+                &quote! { &mut self.0 },
+            ),
+            item::from(
+                ident,
+                &quote! { ::std::string::String },
+                &quote! { Self::new(value) },
+            ),
+            item::from(
+                &quote! { ::std::string::String },
+                ident,
+                &quote! { value.into_inner() },
+            ),
+        ]
+        .into_iter(),
+    );
+
+    let from_str = parse_quote! {
+        impl ::core::str::FromStr for #ident {
+            type Err = ::core::convert::Infallible;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Ok(Self(s.into()))
+            }
+        }
+    };
+
+    Emit {
+        ty,
+        impls,
+        from_str,
+    }
+}
+
 /// Create an [Emit] based on the provided setting.
 fn emit_type(setting: &Setting, name: &str) -> Emit {
     let ident = format_ident!("{}", name.to_case(Case::Pascal));
@@ -274,6 +376,7 @@ fn emit_type(setting: &Setting, name: &str) -> Emit {
             emit_enum(setting, name, &ident, variants, default)
         }
         SettingContent::Path { path } => emit_path(setting, name, &ident, path),
+        SettingContent::String { string } => emit_string(setting, name, &ident, string),
     }
 }
 
@@ -331,6 +434,14 @@ pub fn write(settings: Settings, dest: &Path) {
                 ));
             }
             SettingContent::Path { .. } => {
+                path_field_names.push(format_ident!("{snake_ident}"));
+                path_field_names_mut.push(format_ident!("{snake_ident}_mut"));
+                path_ty_names.push(format_ident!("{pascal_ident}"));
+                path_ty_doc.push(format!(
+                    "Get the [{pascal_ident}][super::{pascal_ident}] setting."
+                ));
+            }
+            SettingContent::String{ .. } => {
                 path_field_names.push(format_ident!("{snake_ident}"));
                 path_field_names_mut.push(format_ident!("{snake_ident}_mut"));
                 path_ty_names.push(format_ident!("{pascal_ident}"));

--- a/spel-katalog-build/src/settings.rs
+++ b/spel-katalog-build/src/settings.rs
@@ -441,7 +441,7 @@ pub fn write(settings: Settings, dest: &Path) {
                     "Get the [{pascal_ident}][super::{pascal_ident}] setting."
                 ));
             }
-            SettingContent::String{ .. } => {
+            SettingContent::String { .. } => {
                 path_field_names.push(format_ident!("{snake_ident}"));
                 path_field_names_mut.push(format_ident!("{snake_ident}_mut"));
                 path_ty_names.push(format_ident!("{pascal_ident}"));

--- a/spel-katalog-info/src/formats.rs
+++ b/spel-katalog-info/src/formats.rs
@@ -5,6 +5,7 @@ use ::std::{
     sync::LazyLock,
 };
 
+use ::rustc_hash::FxHashMap;
 use ::yaml_rust2::{ScanError, Yaml, YamlLoader};
 
 /// A game config.
@@ -12,6 +13,8 @@ use ::yaml_rust2::{ScanError, Yaml, YamlLoader};
 pub struct Config {
     /// Game field.
     pub game: Game,
+    /// System field.
+    pub system: System,
 }
 
 /// Game fields.
@@ -46,14 +49,25 @@ impl Game {
     }
 }
 
+/// System fields.
+#[derive(Debug, Clone, Default)]
+pub struct System {
+    /// Environment variables.
+    pub env: FxHashMap<String, String>,
+}
+
 /// Yaml item to get game field.
 pub static GAME: LazyLock<Yaml> = LazyLock::new(|| Yaml::String("game".into()));
+/// Yaml item to get system field.
+pub static SYSTEM: LazyLock<Yaml> = LazyLock::new(|| Yaml::String("system".into()));
 /// Yaml item to get exe field.
 pub static EXE: LazyLock<Yaml> = LazyLock::new(|| Yaml::String("exe".into()));
 /// Yaml item to get prefix field.
 pub static PREFIX: LazyLock<Yaml> = LazyLock::new(|| Yaml::String("prefix".into()));
 /// Yaml item to get arch field.
 pub static ARCH: LazyLock<Yaml> = LazyLock::new(|| Yaml::String("arch".into()));
+/// Yaml item to get env field.
+pub static ENV: LazyLock<Yaml> = LazyLock::new(|| Yaml::String("env".into()));
 
 /// Get exe of game config.
 fn get_exe(yml: &Yaml) -> Option<PathBuf> {
@@ -85,6 +99,22 @@ fn get_arch(yml: &Yaml) -> Option<String> {
         .map(String::from)
 }
 
+/// Get environment of config.
+fn get_env(yml: &Yaml) -> Option<FxHashMap<String, String>> {
+    yml.as_hash()?
+        .get(&SYSTEM)?
+        .as_hash()?
+        .get(&ENV)?
+        .as_hash()
+        .map(|env| {
+            env.into_iter()
+                .filter_map(|(key, value)| {
+                    Some((key.as_str()?.to_owned(), value.as_str()?.to_owned()))
+                })
+                .collect()
+        })
+}
+
 impl Config {
     /// Parse game config.
     ///
@@ -97,6 +127,9 @@ impl Config {
                 exe: doc.first().and_then(get_exe).unwrap_or_default(),
                 prefix: doc.first().and_then(get_prefix),
                 arch: doc.first().and_then(get_arch),
+            },
+            system: System {
+                env: doc.first().and_then(get_env).unwrap_or_default(),
             },
         })
     }

--- a/spel-katalog-info/src/lib.rs
+++ b/spel-katalog-info/src/lib.rs
@@ -137,6 +137,11 @@ pub enum Request {
         /// Should game be sandboxed.
         sandbox: bool,
     },
+    /// Open shell in game sandbox.
+    OpenShell {
+        /// id of game to open shell for.
+        id: i64,
+    },
     /// Run lutris in sandbox of game.
     RunLutrisInSandbox {
         /// Id of game to run lutris in sandbox of.
@@ -728,6 +733,9 @@ impl State {
                     button("Run")
                         .style(widget::button::danger)
                         .on_press(OrRequest::Request(Request::RunGame { id, sandbox: false })),
+                    button("Shell")
+                        .style(widget::button::secondary)
+                        .on_press(OrRequest::Request(Request::OpenShell { id })),
                     button("Lutris")
                         .on_press(OrRequest::Request(Request::RunLutrisInSandbox { id })),
                     button("+Thumb").padding(3).on_press_maybe(

--- a/spel-katalog-settings/src/settings.toml
+++ b/spel-katalog-settings/src/settings.toml
@@ -37,6 +37,12 @@ help = "How to filter games"
 variants = ["Filter", "Search", "Regex"]
 default = "Search"
 
+[SandboxMode]
+title = "Sandbox Tool"
+help = "How to sandbox games"
+variants = ["Firejail", "Bubblewrap"]
+default = "Firejail"
+
 [OnRun]
 title = "On Run"
 help = "Should any information be opened when running game"
@@ -68,6 +74,16 @@ path = "/usr/bin/lutris"
 title = "Firejail Executable"
 help = "Path to firejail executable"
 path = "/usr/bin/firejail"
+
+[BubblewrapExe]
+title = "Bubblewrap Executable"
+help = "Path to bwrap executable"
+path = "/usr/bin/bwrap"
+
+[UmuRunExe]
+title = "UMU Executable"
+help = "Path to umu-run executable"
+path = "/usr/bin/umu-run"
 
 [CoverartDir]
 title = "Coverart Directory"

--- a/spel-katalog-settings/src/settings.toml
+++ b/spel-katalog-settings/src/settings.toml
@@ -85,6 +85,16 @@ title = "UMU Executable"
 help = "Path to umu-run executable"
 path = "/usr/bin/umu-run"
 
+[ShellExe]
+title = "Shell executable"
+help = "Path to shell executable"
+path = "/usr/bin/bash"
+
+[TermCommand]
+title = "Terminal Command"
+help = "Arguments prepended to command to run in terminal"
+string = "/usr/bin/urxvt -e"
+
 [CoverartDir]
 title = "Coverart Directory"
 help = "Path to coverart directory"

--- a/spel-katalog-settings/src/settings.toml
+++ b/spel-katalog-settings/src/settings.toml
@@ -95,6 +95,11 @@ title = "Terminal Command"
 help = "Arguments prepended to command to run in terminal"
 string = "/usr/bin/urxvt -e"
 
+[SandboxExtras]
+title = "Sandbox Extras"
+help = "Additional paths which may be read from sandbox, separated by ';'"
+string = ""
+
 [CoverartDir]
 title = "Coverart Directory"
 help = "Path to coverart directory"

--- a/spel-katalog/Cargo.toml
+++ b/spel-katalog/Cargo.toml
@@ -49,6 +49,7 @@ strsim.workspace = true
 tap.workspace = true
 thiserror.workspace = true
 toml.workspace = true
+users = { version = "0.11.0", default-features = false }
 yaml-rust2.workspace = true
 
 [build-dependencies]

--- a/spel-katalog/Cargo.toml
+++ b/spel-katalog/Cargo.toml
@@ -49,7 +49,7 @@ strsim.workspace = true
 tap.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-users = { version = "0.11.0", default-features = false }
+users.workspace = true
 yaml-rust2.workspace = true
 
 [build-dependencies]

--- a/spel-katalog/src/message.rs
+++ b/spel-katalog/src/message.rs
@@ -12,12 +12,12 @@ use crate::{
 pub enum Safety {
     None,
     #[default]
-    Firejail,
+    Sandbox,
 }
 
 impl From<bool> for Safety {
     fn from(value: bool) -> Self {
-        if value { Self::Firejail } else { Self::None }
+        if value { Self::Sandbox } else { Self::None }
     }
 }
 

--- a/spel-katalog/src/message.rs
+++ b/spel-katalog/src/message.rs
@@ -74,3 +74,16 @@ pub enum Message {
     #[from]
     ShowInfo(crate::view::Displayed),
 }
+
+impl<T, E> From<Result<T, E>> for Message
+where
+    T: Into<Message>,
+    E: Into<Message>,
+{
+    fn from(value: Result<T, E>) -> Self {
+        match value {
+            Ok(value) => value.into(),
+            Err(value) => value.into(),
+        }
+    }
+}

--- a/spel-katalog/src/message.rs
+++ b/spel-katalog/src/message.rs
@@ -13,6 +13,7 @@ pub enum Safety {
     None,
     #[default]
     Sandbox,
+    SandboxShell,
 }
 
 impl From<bool> for Safety {

--- a/spel-katalog/src/run_game.rs
+++ b/spel-katalog/src/run_game.rs
@@ -244,6 +244,7 @@ struct UmuCtx<'a> {
     bwrap: &'a Path,
     exe: &'a Path,
     umu: &'a Path,
+    wine_prefix: Option<&'a Path>,
     config: &'a Config,
     extra_config: Option<&'a AdditionalConfig>,
     is_net_disabled: bool,
@@ -252,12 +253,31 @@ struct UmuCtx<'a> {
     send_open: Sender<()>,
 }
 
+/// If possible bind user in wine prefix to steamuser in umu prefix.
+fn bind_user(wine_prefix: &Path, umu_prefix: &Path) -> Option<[OsString; 3]> {
+    const USERS: &str = "drive_c/users";
+    let username = ::users::get_current_username()?;
+
+    let wine_home = wine_prefix.join(USERS).join(&username);
+    if !wine_home.exists() {
+        ::log::info!("user {username:?} not found in wine prefix {wine_prefix:?}");
+        return None;
+    }
+
+    let umu_home = umu_prefix.join(USERS).join("steamuser");
+
+    ::log::info!("binding {wine_home:?} to {umu_home:?}");
+
+    Some(args!["--bind", wine_home, umu_home])
+}
+
 async fn umu_run(ctx: UmuCtx<'_>) -> Result<String, StrError> {
     let UmuCtx {
         slug,
         name,
         bwrap,
         exe,
+        wine_prefix,
         umu,
         config,
         extra_config,
@@ -349,6 +369,13 @@ async fn umu_run(ctx: UmuCtx<'_>) -> Result<String, StrError> {
     if !directory_bound {
         args.extend(args!["--bind", &directory, directory,]);
     }
+
+    args.extend(
+        wine_prefix
+            .and_then(|pfx| bind_user(pfx, &umu_prefix))
+            .into_iter()
+            .flatten(),
+    );
 
     args.extend(args!["--chdir", &directory,]);
 
@@ -531,6 +558,7 @@ impl App {
                         slug: &slug,
                         bwrap: bwrap.as_path(),
                         exe: &config.game.exe,
+                        wine_prefix: config.game.prefix.as_deref(),
                         umu: umu.as_path(),
                         config: &config,
                         extra_config: extra_config.as_ref(),

--- a/spel-katalog/src/run_game.rs
+++ b/spel-katalog/src/run_game.rs
@@ -298,7 +298,7 @@ async fn umu_run(ctx: UmuCtx<'_>) -> Result<String, StrError> {
     let umu_dir = home.join(".local/share/umu");
     let umu_prefix = directory.join(".umu_pfx");
 
-    if !umu_prefix.exists() {
+    if !umu_prefix.exists() && config.game.prefix.is_some() {
         let status = ::smol::process::Command::new(umu)
             .arg("")
             .kill_on_drop(true)
@@ -377,9 +377,11 @@ async fn umu_run(ctx: UmuCtx<'_>) -> Result<String, StrError> {
             .flatten(),
     );
 
-    args.extend(args!["--chdir", &directory,]);
+    args.extend(args!["--chdir", directory]);
 
     if let Some(_prefix) = &config.game.prefix {
+        let dir_device = umu_prefix.join("dosdevices").join("g:");
+        args.extend(args!["--symlink", "../..", dir_device]);
         args.extend(args!["--setenv", "WINEPREFIX", umu_prefix, umu,]);
     }
 

--- a/spel-katalog/src/run_game.rs
+++ b/spel-katalog/src/run_game.rs
@@ -360,6 +360,9 @@ impl App {
                     let umu_dir = home.join(".local/share/umu");
                     let umu_prefix = directory.join(".umu_pfx");
 
+                    // TODO: if missing create prefix using umu-run "", with network enabled, then 
+                    // if required fix prefix.
+
                     #[rustfmt::skip]
                     let mut args = Vec::<OsString>::from(args![
                         "--dev", "/dev",
@@ -413,6 +416,10 @@ impl App {
                         args.extend(args!["--share-net"]);
                     }
 
+                    if !directory_bound {
+                        args.extend(args!["--bind", &directory, directory,]);
+                    }
+
                     #[rustfmt::skip]
                     args.extend(args![
                         "--chdir", &directory,
@@ -424,10 +431,6 @@ impl App {
                             "--setenv", "WINEPREFIX", umu_prefix,
                             umu,
                         ]);
-                    }
-
-                    if !directory_bound {
-                        args.extend(args!["--bind", &directory, directory,]);
                     }
 
                     args.extend(args![exe]);

--- a/spel-katalog/src/run_game.rs
+++ b/spel-katalog/src/run_game.rs
@@ -1,6 +1,7 @@
 use ::std::{
     ffi::{OsStr, OsString},
-    path::PathBuf,
+    path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use ::iced_runtime::Task;
@@ -8,12 +9,15 @@ use ::mlua::Lua;
 use ::smol::stream::StreamExt;
 use ::spel_katalog_batch::BatchInfo;
 use ::spel_katalog_common::status;
-use ::spel_katalog_formats::AdditionalConfig;
+use ::spel_katalog_formats::{AdditionalConfig, Runner};
 use ::spel_katalog_info::formats;
-use ::spel_katalog_settings::{ConfigDir, FirejailExe, LutrisExe, Network, OnRun, YmlDir};
-use ::spel_katalog_sink::SinkIdentity;
+use ::spel_katalog_settings::{
+    BubblewrapExe, ConfigDir, FirejailExe, LutrisExe, Network, OnRun, SandboxMode, UmuRunExe,
+    YmlDir,
+};
+use ::spel_katalog_sink::{SinkBuilder, SinkIdentity};
 
-use crate::{App, Message, QuickMessage, Safety, oneshot_broadcast::oneshot_broadcast};
+use crate::{App, Message, QuickMessage, Safety, app::LuaVt, oneshot_broadcast::oneshot_broadcast};
 
 #[derive(Debug, ::thiserror::Error)]
 enum ScriptGatherError {
@@ -78,6 +82,120 @@ async fn gather_scripts(script_dir: PathBuf) -> Result<Vec<PathBuf>, ScriptGathe
     Ok(lua_scripts)
 }
 
+async fn parse_extra_config(extra_config_path: &Path) -> Result<AdditionalConfig, String> {
+    ::toml::from_str::<AdditionalConfig>(
+        &::smol::fs::read_to_string(&extra_config_path)
+            .await
+            .map_err(|err| {
+                ::log::error!("could not read {extra_config_path:?}\n{err}");
+                format!("could not read {extra_config_path:?}")
+            })?,
+    )
+    .map_err(|err| {
+        ::log::error!("could not parse {extra_config_path:?}\n{err}");
+        format!("could not parse {extra_config_path:?}")
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BatchView<'a> {
+    id: i64,
+    slug: &'a str,
+    name: &'a str,
+    runner: &'a Runner,
+    config: &'a str,
+    extra: Option<&'a AdditionalConfig>,
+    hidden: bool,
+}
+
+impl From<BatchView<'_>> for BatchInfo {
+    fn from(
+        BatchView {
+            id,
+            slug,
+            name,
+            runner,
+            config,
+            extra,
+            hidden,
+        }: BatchView,
+    ) -> Self {
+        BatchInfo {
+            id,
+            slug: slug.to_owned(),
+            name: name.to_owned(),
+            runner: runner.to_string(),
+            config: config.to_owned(),
+            attrs: extra
+                .map(|extra_config| extra_config.attrs.clone())
+                .unwrap_or_default(),
+            hidden,
+        }
+    }
+}
+
+async fn run_script(
+    script_dir: PathBuf,
+    batch_view: BatchView<'_>,
+    sink_builder: &SinkBuilder,
+    lua_vt: Arc<LuaVt>,
+) -> Result<(), ScriptGatherError> {
+    let lua_scripts = gather_scripts(script_dir).await?;
+
+    if !lua_scripts.is_empty() {
+        let batch_info = BatchInfo::from(batch_view);
+
+        let sink_builder = sink_builder.clone();
+        ::smol::unblock(move || {
+            let scripts = lua_scripts
+                .into_iter()
+                .map(|path| match ::std::fs::read_to_string(&path) {
+                    Ok(content) => Ok(content),
+                    Err(err) => Err(ScriptGatherError::ReadLuaScript(err, path)),
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let lua = Lua::new();
+            ::spel_katalog_lua::Module {
+                sink_builder: &sink_builder,
+                vt: lua_vt,
+            }
+            .register(&lua)
+            .and_then(|skeleton| {
+                let module = &skeleton.module;
+                let game = batch_info.to_lua(&lua, &skeleton.game_data)?;
+
+                module.set("game", game)?;
+
+                for script in scripts {
+                    lua.load(script).exec()?;
+                }
+
+                Ok(())
+            })
+            .map_err(|err| LuaError(err.to_string()))?;
+            Ok::<_, ScriptGatherError>(())
+        })
+        .await?;
+    }
+
+    Ok(())
+}
+
+/// Convert inputs to an array of [OsString]
+///
+/// ```
+/// assert_eq!(
+///     args!["echo", "Hello", "World!"],
+///     [OsString::from("echo"), OsString::from("Hello"), OsString::from("World!")]
+/// );
+/// ```
+macro_rules! args {
+    ($($arg:expr),* $(,)?) => {
+        [$(OsString::from($arg)),*]
+    };
+}
+
 impl App {
     pub fn run_game(&mut self, id: i64, safety: Safety, no_game: bool) -> Task<Message> {
         let Some(game) = self.games.by_id(id) else {
@@ -87,6 +205,9 @@ impl App {
 
         let lutris = self.settings.get::<LutrisExe>().clone();
         let firejail = self.settings.get::<FirejailExe>().clone();
+        let bwrap = self.settings.get::<BubblewrapExe>().clone();
+        let umu = self.settings.get::<UmuRunExe>().clone();
+        let sandbox_mode = *self.settings.get::<SandboxMode>();
         let slug = game.slug.clone();
         let name = game.name.clone();
         let runner = game.runner.clone();
@@ -126,7 +247,6 @@ impl App {
             let config = async {
                 let config = ::smol::fs::read_to_string(&configpath).await?;
                 let config = formats::Config::parse(&config)?;
-
                 Ok::<_, ConfigError>(config)
             };
 
@@ -139,80 +259,25 @@ impl App {
             };
 
             let extra_config = if extra_config_path.exists() {
-                let Some(content) = ::smol::fs::read_to_string(&extra_config_path)
-                    .await
-                    .map_err(|err| ::log::error!("could not read {extra_config_path:?}\n{err}"))
-                    .ok()
-                else {
-                    return format!("could not read {extra_config_path:?}").into();
-                };
-                let Some(additional) = ::toml::from_str::<AdditionalConfig>(&content)
-                    .map_err(|err| ::log::error!("could not parse {extra_config_path:?}\n{err}"))
-                    .ok()
-                else {
-                    return format!("could not parse {extra_config_path:?}").into();
-                };
-
-                Some(additional)
+                match parse_extra_config(&extra_config_path).await {
+                    Err(err) => return err.into(),
+                    Ok(additional) => Some(additional),
+                }
             } else {
                 None
             };
 
-            let scripts_result = async {
-                let lua_scripts = gather_scripts(script_dir).await?;
-
-                if !lua_scripts.is_empty() {
-                    let batch_info = BatchInfo {
-                        id,
-                        slug: slug.clone(),
-                        name: name.clone(),
-                        runner: runner.to_string(),
-                        config: configpath.clone(),
-                        attrs: extra_config
-                            .as_ref()
-                            .map(|extra_config| extra_config.attrs.clone())
-                            .unwrap_or_default(),
-                        hidden,
-                    };
-
-                    let sink_builder = sink_builder.clone();
-                    ::smol::unblock(move || {
-                        let scripts = lua_scripts
-                            .into_iter()
-                            .map(|path| match ::std::fs::read_to_string(&path) {
-                                Ok(content) => Ok(content),
-                                Err(err) => Err(ScriptGatherError::ReadLuaScript(err, path)),
-                            })
-                            .collect::<Result<Vec<_>, _>>()?;
-
-                        let lua = Lua::new();
-                        ::spel_katalog_lua::Module {
-                            sink_builder: &sink_builder,
-                            vt: lua_vt,
-                        }
-                        .register(&lua)
-                        .and_then(|skeleton| {
-                            let module = &skeleton.module;
-                            let game = batch_info.to_lua(&lua, &skeleton.game_data)?;
-
-                            module.set("game", game)?;
-
-                            for script in scripts {
-                                lua.load(script).exec()?;
-                            }
-
-                            Ok(())
-                        })
-                        .map_err(|err| LuaError(err.to_string()))?;
-                        Ok::<_, ScriptGatherError>(())
-                    })
-                    .await?;
-                }
-
-                Ok::<_, ScriptGatherError>(())
+            let view = BatchView {
+                id,
+                slug: &slug,
+                name: &name,
+                runner: &runner,
+                config: &configpath,
+                extra: extra_config.as_ref(),
+                hidden,
             };
 
-            if let Err(err) = scripts_result.await {
+            if let Err(err) = run_script(script_dir, view, &sink_builder, lua_vt).await {
                 ::log::error!("failure when gathering/runnings scripts\n{err}");
                 return "running scripts failed".to_owned().into();
             }
@@ -238,8 +303,8 @@ impl App {
                 }
             };
 
-            let cmd = match safety {
-                Safety::None => {
+            let cmd = match (safety, sandbox_mode) {
+                (Safety::None, _) => {
                     ::log::info!("executing {lutris:?} with arguments\n{:#?}", &[&rungame]);
                     ::smol::process::Command::new(lutris)
                         .args(rungame)
@@ -248,7 +313,7 @@ impl App {
                         .stderr(stderr)
                         .status()
                 }
-                Safety::Firejail => {
+                (Safety::Sandbox, SandboxMode::Firejail) => {
                     let mut args = Vec::new();
                     ::log::info!("parsed game config\n{config:#?}");
                     if let Some(additional) = extra_config
@@ -273,6 +338,103 @@ impl App {
                     ::log::info!("executing {firejail:?} with arguments\n{args:#?}");
 
                     ::smol::process::Command::new(firejail)
+                        .args(args)
+                        .kill_on_drop(true)
+                        .stdout(stdout)
+                        .stderr(stderr)
+                        .status()
+                }
+                (Safety::Sandbox, SandboxMode::Bubblewrap) => {
+                    let bwrap = bwrap.as_path();
+                    let Some(home) = ::std::env::home_dir() else {
+                        ::log::error!("could not find user home directory");
+                        return "could not find user home directory".to_owned().into();
+                    };
+                    let exe = config.game.exe.as_path();
+                    let umu = umu.as_path();
+                    let Some(directory) = config.game.exe.parent() else {
+                        ::log::error!("executable {exe:?} has no parent");
+                        return "missing executable parent".to_owned().into();
+                    };
+                    let xauthority = home.join(".Xauthority");
+                    let umu_dir = home.join(".local/share/umu");
+                    let umu_prefix = directory.join(".umu_pfx");
+
+                    #[rustfmt::skip]
+                    let mut args = Vec::<OsString>::from(args![
+                        "--dev", "/dev",
+                        "--proc", "/proc",
+                        "--ro-bind", "/usr", "/usr",
+                        "--ro-bind", "/etc", "/etc",
+                        "--ro-bind", "/var", "/var",
+                        "--ro-bind", "/run", "/run",
+                        "--ro-bind", "/sys", "/sys",
+                        "--ro-bind-try", "/opt/rocm", "/opt/rocm",
+                        "--symlink", "/usr/lib", "/lib",
+                        "--symlink", "/usr/lib64", "/lib64",
+                        "--symlink", "/usr/lib32", "/lib32",
+                        "--symlink", "/usr/bin", "/bin",
+                        "--symlink", "/usr/bin", "/sbin",
+                        "--tmpfs", "/home",
+                        "--tmpfs", "/tmp",
+                        "--ro-bind", "/tmp/.X11-unix/X0", "/tmp/.X11-unix/X0",
+                        "--ro-bind", &xauthority, xauthority,
+                        "--dev-bind", "/dev/dri", "/dev/dri",
+                        "--bind", &umu_dir, umu_dir,
+                        "--setenv", "PATH", "/usr/bin",
+                        "--hostname", "games",
+                        "--die-with-parent",
+                        "--new-session",
+                        "--unshare-all",
+                    ]);
+
+                    let additional_roots = extra_config
+                        .as_ref()
+                        .map_or(&[][..], |extra| extra.sandbox_root.as_slice());
+
+                    let mut directory_bound = false;
+                    if additional_roots.is_empty() {
+                        let common_parent = config.game.common_parent();
+                        if common_parent == directory {
+                            directory_bound = true;
+                        }
+                        args.extend(args!["--bind", &common_parent, common_parent]);
+                    } else {
+                        for root in additional_roots {
+                            if root == directory {
+                                directory_bound = true;
+                            }
+                            args.extend(args!["--bind", root, root]);
+                        }
+                    }
+                    let directory_bound = directory_bound;
+
+                    if !is_net_disabled {
+                        args.extend(args!["--share-net"]);
+                    }
+
+                    #[rustfmt::skip]
+                    args.extend(args![
+                        "--chdir", &directory,
+                    ]);
+
+                    if let Some(_prefix) = &config.game.prefix {
+                        #[rustfmt::skip]
+                        args.extend(args![
+                            "--setenv", "WINEPREFIX", umu_prefix,
+                            umu,
+                        ]);
+                    }
+
+                    if !directory_bound {
+                        args.extend(args!["--bind", &directory, directory,]);
+                    }
+
+                    args.extend(args![exe]);
+
+                    ::log::info!("running with config {args:#?}");
+
+                    ::smol::process::Command::new(bwrap)
                         .args(args)
                         .kill_on_drop(true)
                         .stdout(stdout)

--- a/spel-katalog/src/run_game.rs
+++ b/spel-katalog/src/run_game.rs
@@ -1,6 +1,8 @@
+use ::core::fmt::{Arguments, Display};
 use ::std::{
     ffi::{OsStr, OsString},
     path::{Path, PathBuf},
+    process::Stdio,
     sync::Arc,
 };
 
@@ -10,14 +12,67 @@ use ::smol::stream::StreamExt;
 use ::spel_katalog_batch::BatchInfo;
 use ::spel_katalog_common::status;
 use ::spel_katalog_formats::{AdditionalConfig, Runner};
-use ::spel_katalog_info::formats;
+use ::spel_katalog_info::formats::{self, Config};
 use ::spel_katalog_settings::{
     BubblewrapExe, ConfigDir, FirejailExe, LutrisExe, Network, OnRun, SandboxMode, UmuRunExe,
     YmlDir,
 };
 use ::spel_katalog_sink::{SinkBuilder, SinkIdentity};
 
-use crate::{App, Message, QuickMessage, Safety, app::LuaVt, oneshot_broadcast::oneshot_broadcast};
+use crate::{
+    App, Message, QuickMessage, Safety,
+    app::LuaVt,
+    oneshot_broadcast::{Sender, oneshot_broadcast},
+};
+
+/// Convert inputs to an array of [OsString]
+///
+/// ```
+/// assert_eq!(
+///     args!["echo", "Hello", "World!"],
+///     [OsString::from("echo"), OsString::from("Hello"), OsString::from("World!")]
+/// );
+/// ```
+macro_rules! args {
+    ($($arg:expr),* $(,)?) => {
+        [$(OsString::from($arg)),*]
+    };
+}
+
+/// Error type converting error to a string.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct StrError(String);
+
+impl StrError {
+    /// Create formatted string errror.
+    pub fn fmt(args: Arguments<'_>) -> Self {
+        Self(::std::fmt::format(args))
+    }
+}
+
+impl<E: ::core::error::Error> From<E> for StrError {
+    fn from(value: E) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl Display for StrError {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        <String as Display>::fmt(&self.0, f)
+    }
+}
+
+impl From<StrError> for Message {
+    fn from(value: StrError) -> Self {
+        value.0.into()
+    }
+}
+
+macro_rules! strerror {
+    ($($arg:tt)*) => {
+        StrError::fmt(format_args!($($arg)*))
+    };
+}
 
 #[derive(Debug, ::thiserror::Error)]
 enum ScriptGatherError {
@@ -182,18 +237,144 @@ async fn run_script(
     Ok(())
 }
 
-/// Convert inputs to an array of [OsString]
-///
-/// ```
-/// assert_eq!(
-///     args!["echo", "Hello", "World!"],
-///     [OsString::from("echo"), OsString::from("Hello"), OsString::from("World!")]
-/// );
-/// ```
-macro_rules! args {
-    ($($arg:expr),* $(,)?) => {
-        [$(OsString::from($arg)),*]
-    };
+#[derive(Debug)]
+struct UmuCtx<'a> {
+    slug: &'a str,
+    name: &'a str,
+    bwrap: &'a Path,
+    exe: &'a Path,
+    umu: &'a Path,
+    config: &'a Config,
+    extra_config: Option<&'a AdditionalConfig>,
+    is_net_disabled: bool,
+    stdout: Stdio,
+    stderr: Stdio,
+    send_open: Sender<()>,
+}
+
+async fn umu_run(ctx: UmuCtx<'_>) -> Result<String, StrError> {
+    let UmuCtx {
+        slug,
+        name,
+        bwrap,
+        exe,
+        umu,
+        config,
+        extra_config,
+        is_net_disabled,
+        stdout,
+        stderr,
+        send_open,
+    } = ctx;
+    let home = ::std::env::home_dir().ok_or_else(|| {
+        ::log::error!("could not find user home directory");
+        StrError("could not find user home directory".to_owned())
+    })?;
+    let directory = exe.parent().ok_or_else(|| {
+        ::log::error!("executable {exe:?} has no parent");
+        StrError("missing executable parent".to_owned())
+    })?;
+    let xauthority = home.join(".Xauthority");
+    let umu_dir = home.join(".local/share/umu");
+    let umu_prefix = directory.join(".umu_pfx");
+
+    if !umu_prefix.exists() {
+        let status = ::smol::process::Command::new(umu)
+            .arg("")
+            .kill_on_drop(true)
+            .status()
+            .await
+            .map_err(|err| {
+                ::log::error!("could not run command to create umu prefix {umu_prefix:?}, {err}");
+                strerror!("could not create umu prefix")
+            })?;
+
+        if !status.success() {
+            ::log::error!("failed to create umu prefix {status:?}");
+            return Err(strerror!("could not create umu prefix"));
+        }
+    }
+
+    #[rustfmt::skip]
+    let mut args = Vec::<OsString>::from(args![
+        "--dev", "/dev",
+        "--proc", "/proc",
+        "--ro-bind", "/usr", "/usr",
+        "--ro-bind", "/etc", "/etc",
+        "--ro-bind", "/var", "/var",
+        "--ro-bind", "/run", "/run",
+        "--ro-bind", "/sys", "/sys",
+        "--ro-bind-try", "/opt/rocm", "/opt/rocm",
+        "--symlink", "/usr/lib", "/lib",
+        "--symlink", "/usr/lib64", "/lib64",
+        "--symlink", "/usr/lib32", "/lib32",
+        "--symlink", "/usr/bin", "/bin",
+        "--symlink", "/usr/bin", "/sbin",
+        "--tmpfs", "/home",
+        "--tmpfs", "/tmp",
+        "--ro-bind", "/tmp/.X11-unix/X0", "/tmp/.X11-unix/X0",
+        "--ro-bind", &xauthority, xauthority,
+        "--dev-bind", "/dev/dri", "/dev/dri",
+        "--bind", &umu_dir, umu_dir,
+        "--setenv", "PATH", "/usr/bin",
+        "--hostname", "games",
+        "--die-with-parent",
+        "--new-session",
+        "--unshare-all",
+    ]);
+
+    let additional_roots = extra_config.map_or(&[][..], |extra| extra.sandbox_root.as_slice());
+
+    let mut directory_bound = false;
+    if additional_roots.is_empty() {
+        let common_parent = config.game.common_parent();
+        if common_parent == directory {
+            directory_bound = true;
+        }
+        args.extend(args!["--bind", &common_parent, common_parent]);
+    } else {
+        for root in additional_roots {
+            if root == directory {
+                directory_bound = true;
+            }
+            args.extend(args!["--bind", root, root]);
+        }
+    }
+    let directory_bound = directory_bound;
+
+    if !is_net_disabled {
+        args.extend(args!["--share-net"]);
+    }
+
+    if !directory_bound {
+        args.extend(args!["--bind", &directory, directory,]);
+    }
+
+    args.extend(args!["--chdir", &directory,]);
+
+    if let Some(_prefix) = &config.game.prefix {
+        args.extend(args!["--setenv", "WINEPREFIX", umu_prefix, umu,]);
+    }
+
+    args.extend(args![exe]);
+
+    ::log::info!("running with config {args:#?}");
+
+    let cmd = ::smol::process::Command::new(bwrap)
+        .args(args)
+        .kill_on_drop(true)
+        .stdout(stdout)
+        .stderr(stderr)
+        .status();
+
+    send_open.send(());
+
+    let status = cmd.await.map_err(|err| {
+        ::log::error!("could not run {slug}\n{err}");
+        strerror!("could not run {slug}")
+    })?;
+
+    Ok(format!("{name} exited with {status}"))
 }
 
 impl App {
@@ -345,104 +526,21 @@ impl App {
                         .status()
                 }
                 (Safety::Sandbox, SandboxMode::Bubblewrap) => {
-                    let bwrap = bwrap.as_path();
-                    let Some(home) = ::std::env::home_dir() else {
-                        ::log::error!("could not find user home directory");
-                        return "could not find user home directory".to_owned().into();
-                    };
-                    let exe = config.game.exe.as_path();
-                    let umu = umu.as_path();
-                    let Some(directory) = config.game.exe.parent() else {
-                        ::log::error!("executable {exe:?} has no parent");
-                        return "missing executable parent".to_owned().into();
-                    };
-                    let xauthority = home.join(".Xauthority");
-                    let umu_dir = home.join(".local/share/umu");
-                    let umu_prefix = directory.join(".umu_pfx");
-
-                    // TODO: if missing create prefix using umu-run "", with network enabled, then 
-                    // if required fix prefix.
-
-                    #[rustfmt::skip]
-                    let mut args = Vec::<OsString>::from(args![
-                        "--dev", "/dev",
-                        "--proc", "/proc",
-                        "--ro-bind", "/usr", "/usr",
-                        "--ro-bind", "/etc", "/etc",
-                        "--ro-bind", "/var", "/var",
-                        "--ro-bind", "/run", "/run",
-                        "--ro-bind", "/sys", "/sys",
-                        "--ro-bind-try", "/opt/rocm", "/opt/rocm",
-                        "--symlink", "/usr/lib", "/lib",
-                        "--symlink", "/usr/lib64", "/lib64",
-                        "--symlink", "/usr/lib32", "/lib32",
-                        "--symlink", "/usr/bin", "/bin",
-                        "--symlink", "/usr/bin", "/sbin",
-                        "--tmpfs", "/home",
-                        "--tmpfs", "/tmp",
-                        "--ro-bind", "/tmp/.X11-unix/X0", "/tmp/.X11-unix/X0",
-                        "--ro-bind", &xauthority, xauthority,
-                        "--dev-bind", "/dev/dri", "/dev/dri",
-                        "--bind", &umu_dir, umu_dir,
-                        "--setenv", "PATH", "/usr/bin",
-                        "--hostname", "games",
-                        "--die-with-parent",
-                        "--new-session",
-                        "--unshare-all",
-                    ]);
-
-                    let additional_roots = extra_config
-                        .as_ref()
-                        .map_or(&[][..], |extra| extra.sandbox_root.as_slice());
-
-                    let mut directory_bound = false;
-                    if additional_roots.is_empty() {
-                        let common_parent = config.game.common_parent();
-                        if common_parent == directory {
-                            directory_bound = true;
-                        }
-                        args.extend(args!["--bind", &common_parent, common_parent]);
-                    } else {
-                        for root in additional_roots {
-                            if root == directory {
-                                directory_bound = true;
-                            }
-                            args.extend(args!["--bind", root, root]);
-                        }
-                    }
-                    let directory_bound = directory_bound;
-
-                    if !is_net_disabled {
-                        args.extend(args!["--share-net"]);
-                    }
-
-                    if !directory_bound {
-                        args.extend(args!["--bind", &directory, directory,]);
-                    }
-
-                    #[rustfmt::skip]
-                    args.extend(args![
-                        "--chdir", &directory,
-                    ]);
-
-                    if let Some(_prefix) = &config.game.prefix {
-                        #[rustfmt::skip]
-                        args.extend(args![
-                            "--setenv", "WINEPREFIX", umu_prefix,
-                            umu,
-                        ]);
-                    }
-
-                    args.extend(args![exe]);
-
-                    ::log::info!("running with config {args:#?}");
-
-                    ::smol::process::Command::new(bwrap)
-                        .args(args)
-                        .kill_on_drop(true)
-                        .stdout(stdout)
-                        .stderr(stderr)
-                        .status()
+                    return umu_run(UmuCtx {
+                        name: &name,
+                        slug: &slug,
+                        bwrap: bwrap.as_path(),
+                        exe: &config.game.exe,
+                        umu: umu.as_path(),
+                        config: &config,
+                        extra_config: extra_config.as_ref(),
+                        is_net_disabled,
+                        stdout,
+                        stderr,
+                        send_open,
+                    })
+                    .await
+                    .into();
                 }
             };
 

--- a/spel-katalog/src/run_game.rs
+++ b/spel-katalog/src/run_game.rs
@@ -8,8 +8,8 @@ use ::spel_katalog_common::status;
 use ::spel_katalog_formats::AdditionalConfig;
 use ::spel_katalog_info::formats;
 use ::spel_katalog_settings::{
-    BubblewrapExe, ConfigDir, FirejailExe, LutrisExe, Network, OnRun, SandboxMode, ShellExe,
-    TermCommand, UmuRunExe, YmlDir,
+    BubblewrapExe, ConfigDir, FirejailExe, LutrisExe, Network, OnRun, SandboxExtras, SandboxMode,
+    ShellExe, TermCommand, UmuRunExe, YmlDir,
 };
 use ::spel_katalog_sink::SinkIdentity;
 
@@ -81,6 +81,7 @@ impl App {
         let umu = self.settings.get::<UmuRunExe>().clone();
         let shell = self.settings.get::<ShellExe>().clone();
         let sandbox_mode = *self.settings.get::<SandboxMode>();
+        let sandbox_extras = self.settings.get::<SandboxExtras>().clone();
         let slug = game.slug.clone();
         let name = game.name.clone();
         let runner = game.runner.clone();
@@ -212,21 +213,22 @@ impl App {
                 (Safety::Sandbox, SandboxMode::Bubblewrap) => {
                     return umu_run(
                         UmuCtx {
-                            name: &name,
-                            slug: &slug,
                             bwrap: bwrap.as_path(),
-                            shell: shell.as_path(),
-                            term: &term,
-                            exe: &config.game.exe,
-                            wine_prefix: config.game.prefix.as_deref(),
-                            umu: umu.as_path(),
                             config: &config,
+                            exe: &config.game.exe,
                             extra_config: extra_config.as_ref(),
                             is_net_disabled,
-                            stdout,
-                            stderr,
-                            send_open,
+                            name: &name,
                             runner,
+                            sandbox_extras: &sandbox_extras,
+                            send_open,
+                            shell: shell.as_path(),
+                            slug: &slug,
+                            stderr,
+                            stdout,
+                            term: &term,
+                            umu: umu.as_path(),
+                            wine_prefix: config.game.prefix.as_deref(),
                         },
                         false,
                     )
@@ -236,21 +238,22 @@ impl App {
                 (Safety::SandboxShell, SandboxMode::Bubblewrap) => {
                     return umu_run(
                         UmuCtx {
-                            name: &name,
-                            slug: &slug,
                             bwrap: bwrap.as_path(),
-                            shell: shell.as_path(),
-                            term: &term,
-                            exe: &config.game.exe,
-                            wine_prefix: config.game.prefix.as_deref(),
-                            umu: umu.as_path(),
                             config: &config,
+                            exe: &config.game.exe,
                             extra_config: extra_config.as_ref(),
                             is_net_disabled,
-                            stdout,
-                            stderr,
-                            send_open,
+                            name: &name,
                             runner,
+                            sandbox_extras: &sandbox_extras,
+                            send_open,
+                            shell: shell.as_path(),
+                            slug: &slug,
+                            stderr,
+                            stdout,
+                            term: &term,
+                            umu: umu.as_path(),
+                            wine_prefix: config.game.prefix.as_deref(),
                         },
                         true,
                     )

--- a/spel-katalog/src/run_game.rs
+++ b/spel-katalog/src/run_game.rs
@@ -1,78 +1,31 @@
-use ::core::fmt::{Arguments, Display};
 use ::std::{
     ffi::{OsStr, OsString},
     path::{Path, PathBuf},
-    process::Stdio,
-    sync::Arc,
 };
 
 use ::iced_runtime::Task;
-use ::mlua::Lua;
-use ::smol::stream::StreamExt;
-use ::spel_katalog_batch::BatchInfo;
 use ::spel_katalog_common::status;
-use ::spel_katalog_formats::{AdditionalConfig, Runner};
-use ::spel_katalog_info::formats::{self, Config};
+use ::spel_katalog_formats::AdditionalConfig;
+use ::spel_katalog_info::formats;
 use ::spel_katalog_settings::{
-    BubblewrapExe, ConfigDir, FirejailExe, LutrisExe, Network, OnRun, SandboxMode, UmuRunExe,
-    YmlDir,
+    BubblewrapExe, ConfigDir, FirejailExe, LutrisExe, Network, OnRun, SandboxMode, ShellExe,
+    TermCommand, UmuRunExe, YmlDir,
 };
-use ::spel_katalog_sink::{SinkBuilder, SinkIdentity};
+use ::spel_katalog_sink::SinkIdentity;
 
 use crate::{
     App, Message, QuickMessage, Safety,
-    app::LuaVt,
-    oneshot_broadcast::{Sender, oneshot_broadcast},
+    oneshot_broadcast::oneshot_broadcast,
+    run_game::{
+        run_script::BatchView,
+        run_umu::{UmuCtx, umu_run},
+    },
 };
 
-/// Convert inputs to an array of [OsString]
-///
-/// ```
-/// assert_eq!(
-///     args!["echo", "Hello", "World!"],
-///     [OsString::from("echo"), OsString::from("Hello"), OsString::from("World!")]
-/// );
-/// ```
-macro_rules! args {
-    ($($arg:expr),* $(,)?) => {
-        [$(OsString::from($arg)),*]
-    };
-}
-
-/// Error type converting error to a string.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-struct StrError(String);
-
-impl StrError {
-    /// Create formatted string errror.
-    pub fn fmt(args: Arguments<'_>) -> Self {
-        Self(::std::fmt::format(args))
-    }
-}
-
-impl<E: ::core::error::Error> From<E> for StrError {
-    fn from(value: E) -> Self {
-        Self(value.to_string())
-    }
-}
-
-impl Display for StrError {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        <String as Display>::fmt(&self.0, f)
-    }
-}
-
-impl From<StrError> for Message {
-    fn from(value: StrError) -> Self {
-        value.0.into()
-    }
-}
-
-macro_rules! strerror {
-    ($($arg:tt)*) => {
-        StrError::fmt(format_args!($($arg)*))
-    };
-}
+mod macros;
+mod run_script;
+mod run_umu;
+mod strerror;
 
 #[derive(Debug, ::thiserror::Error)]
 enum ScriptGatherError {
@@ -99,44 +52,6 @@ enum ConfigError {
     Scan(#[from] ::yaml_rust2::ScanError),
 }
 
-async fn gather_scripts(script_dir: PathBuf) -> Result<Vec<PathBuf>, ScriptGatherError> {
-    if !script_dir.exists() {
-        ::log::info!("no script dir, skipping");
-        return Ok(Vec::new());
-    }
-    let mut lua_scripts = Vec::new();
-    let mut stack = Vec::new();
-
-    stack.push(script_dir);
-
-    while let Some(dir) = stack.pop() {
-        let mut dir = ::smol::fs::read_dir(dir).await?;
-        while let Some(entry) = dir.next().await.transpose()? {
-            let ft = entry.file_type().await?;
-
-            let path = entry.path();
-
-            if ft.is_dir() {
-                stack.push(path);
-            } else if ft.is_file() {
-                if path
-                    .extension()
-                    .and_then(|ext| ext.to_str())
-                    .is_some_and(|ext| ext.eq_ignore_ascii_case("lua"))
-                {
-                    lua_scripts.push(path);
-                }
-            } else {
-                ::log::warn!("non file or directory path in script dir, {path:?}")
-            }
-        }
-    }
-
-    lua_scripts.sort_unstable();
-
-    Ok(lua_scripts)
-}
-
 async fn parse_extra_config(extra_config_path: &Path) -> Result<AdditionalConfig, String> {
     ::toml::from_str::<AdditionalConfig>(
         &::smol::fs::read_to_string(&extra_config_path)
@@ -152,268 +67,6 @@ async fn parse_extra_config(extra_config_path: &Path) -> Result<AdditionalConfig
     })
 }
 
-#[derive(Debug, Clone, Copy)]
-struct BatchView<'a> {
-    id: i64,
-    slug: &'a str,
-    name: &'a str,
-    runner: &'a Runner,
-    config: &'a str,
-    extra: Option<&'a AdditionalConfig>,
-    hidden: bool,
-}
-
-impl From<BatchView<'_>> for BatchInfo {
-    fn from(
-        BatchView {
-            id,
-            slug,
-            name,
-            runner,
-            config,
-            extra,
-            hidden,
-        }: BatchView,
-    ) -> Self {
-        BatchInfo {
-            id,
-            slug: slug.to_owned(),
-            name: name.to_owned(),
-            runner: runner.to_string(),
-            config: config.to_owned(),
-            attrs: extra
-                .map(|extra_config| extra_config.attrs.clone())
-                .unwrap_or_default(),
-            hidden,
-        }
-    }
-}
-
-async fn run_script(
-    script_dir: PathBuf,
-    batch_view: BatchView<'_>,
-    sink_builder: &SinkBuilder,
-    lua_vt: Arc<LuaVt>,
-) -> Result<(), ScriptGatherError> {
-    let lua_scripts = gather_scripts(script_dir).await?;
-
-    if !lua_scripts.is_empty() {
-        let batch_info = BatchInfo::from(batch_view);
-
-        let sink_builder = sink_builder.clone();
-        ::smol::unblock(move || {
-            let scripts = lua_scripts
-                .into_iter()
-                .map(|path| match ::std::fs::read_to_string(&path) {
-                    Ok(content) => Ok(content),
-                    Err(err) => Err(ScriptGatherError::ReadLuaScript(err, path)),
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            let lua = Lua::new();
-            ::spel_katalog_lua::Module {
-                sink_builder: &sink_builder,
-                vt: lua_vt,
-            }
-            .register(&lua)
-            .and_then(|skeleton| {
-                let module = &skeleton.module;
-                let game = batch_info.to_lua(&lua, &skeleton.game_data)?;
-
-                module.set("game", game)?;
-
-                for script in scripts {
-                    lua.load(script).exec()?;
-                }
-
-                Ok(())
-            })
-            .map_err(|err| LuaError(err.to_string()))?;
-            Ok::<_, ScriptGatherError>(())
-        })
-        .await?;
-    }
-
-    Ok(())
-}
-
-#[derive(Debug)]
-struct UmuCtx<'a> {
-    slug: &'a str,
-    name: &'a str,
-    bwrap: &'a Path,
-    exe: &'a Path,
-    umu: &'a Path,
-    wine_prefix: Option<&'a Path>,
-    config: &'a Config,
-    extra_config: Option<&'a AdditionalConfig>,
-    is_net_disabled: bool,
-    stdout: Stdio,
-    stderr: Stdio,
-    send_open: Sender<()>,
-}
-
-/// If possible bind user in wine prefix to steamuser in umu prefix.
-fn bind_user(wine_prefix: &Path, umu_prefix: &Path) -> Option<[OsString; 3]> {
-    const USERS: &str = "drive_c/users";
-    let username = ::users::get_current_username()?;
-
-    let wine_home = wine_prefix.join(USERS).join(&username);
-    if !wine_home.exists() {
-        ::log::info!("user {username:?} not found in wine prefix {wine_prefix:?}");
-        return None;
-    }
-
-    let umu_home = umu_prefix.join(USERS).join("steamuser");
-
-    ::log::info!("binding {wine_home:?} to {umu_home:?}");
-
-    Some(args!["--bind", wine_home, umu_home])
-}
-
-async fn umu_run(ctx: UmuCtx<'_>) -> Result<String, StrError> {
-    let UmuCtx {
-        slug,
-        name,
-        bwrap,
-        exe,
-        wine_prefix,
-        umu,
-        config,
-        extra_config,
-        is_net_disabled,
-        stdout,
-        stderr,
-        send_open,
-    } = ctx;
-    let home = ::std::env::home_dir().ok_or_else(|| {
-        ::log::error!("could not find user home directory");
-        StrError("could not find user home directory".to_owned())
-    })?;
-    let directory = exe.parent().ok_or_else(|| {
-        ::log::error!("executable {exe:?} has no parent");
-        StrError("missing executable parent".to_owned())
-    })?;
-    let xauthority = home.join(".Xauthority");
-    let umu_dir = home.join(".local/share/umu");
-    let umu_prefix = directory.join(".umu_pfx");
-
-    if !umu_prefix.exists() && config.game.prefix.is_some() {
-        let status = ::smol::process::Command::new(umu)
-            .arg("")
-            .kill_on_drop(true)
-            .status()
-            .await
-            .map_err(|err| {
-                ::log::error!("could not run command to create umu prefix {umu_prefix:?}, {err}");
-                strerror!("could not create umu prefix")
-            })?;
-
-        if !status.success() {
-            ::log::error!("failed to create umu prefix {status:?}");
-            return Err(strerror!("could not create umu prefix"));
-        }
-    }
-
-    #[rustfmt::skip]
-    let mut args = Vec::<OsString>::from(args![
-        "--dev", "/dev",
-        "--proc", "/proc",
-        "--ro-bind", "/usr", "/usr",
-        "--ro-bind", "/etc", "/etc",
-        "--ro-bind", "/var", "/var",
-        "--ro-bind", "/run", "/run",
-        "--ro-bind", "/sys", "/sys",
-        "--ro-bind-try", "/opt/rocm", "/opt/rocm",
-        "--symlink", "/usr/lib", "/lib",
-        "--symlink", "/usr/lib64", "/lib64",
-        "--symlink", "/usr/lib32", "/lib32",
-        "--symlink", "/usr/bin", "/bin",
-        "--symlink", "/usr/bin", "/sbin",
-        "--tmpfs", "/home",
-        "--tmpfs", "/tmp",
-        "--ro-bind", "/tmp/.X11-unix/X0", "/tmp/.X11-unix/X0",
-        "--ro-bind", &xauthority, xauthority,
-        "--dev-bind", "/dev/dri", "/dev/dri",
-        "--bind", &umu_dir, umu_dir,
-        "--setenv", "PATH", "/usr/bin",
-        "--hostname", "games",
-        "--die-with-parent",
-        "--new-session",
-        "--unshare-all",
-    ]);
-
-    let additional_roots = extra_config.map_or(&[][..], |extra| extra.sandbox_root.as_slice());
-
-    let mut directory_bound = false;
-    if additional_roots.is_empty() {
-        let common_parent = config.game.common_parent();
-        if common_parent == directory {
-            directory_bound = true;
-        }
-        args.extend(args!["--bind", &common_parent, common_parent]);
-    } else {
-        for root in additional_roots {
-            if root == directory {
-                directory_bound = true;
-            }
-            args.extend(args!["--bind", root, root]);
-        }
-    }
-    let directory_bound = directory_bound;
-
-    if !is_net_disabled {
-        args.extend(args!["--share-net"]);
-    }
-
-    if !directory_bound {
-        args.extend(args!["--bind", &directory, directory,]);
-    }
-
-    args.extend(
-        wine_prefix
-            .and_then(|pfx| bind_user(pfx, &umu_prefix))
-            .into_iter()
-            .flatten(),
-    );
-
-    args.extend(
-        config
-            .system
-            .env
-            .iter()
-            .flat_map(|(key, value)| args!["--setenv", key, value]),
-    );
-
-    args.extend(args!["--chdir", directory]);
-
-    if let Some(_prefix) = &config.game.prefix {
-        let dir_device = umu_prefix.join("dosdevices").join("g:");
-        args.extend(args!["--symlink", "../..", dir_device]);
-        args.extend(args!["--setenv", "WINEPREFIX", umu_prefix, umu,]);
-    }
-
-    args.extend(args![exe]);
-
-    ::log::info!("running with config {args:#?}");
-
-    let cmd = ::smol::process::Command::new(bwrap)
-        .args(args)
-        .kill_on_drop(true)
-        .stdout(stdout)
-        .stderr(stderr)
-        .status();
-
-    send_open.send(());
-
-    let status = cmd.await.map_err(|err| {
-        ::log::error!("could not run {slug}\n{err}");
-        strerror!("could not run {slug}")
-    })?;
-
-    Ok(format!("{name} exited with {status}"))
-}
-
 impl App {
     pub fn run_game(&mut self, id: i64, safety: Safety, no_game: bool) -> Task<Message> {
         let Some(game) = self.games.by_id(id) else {
@@ -423,8 +76,10 @@ impl App {
 
         let lutris = self.settings.get::<LutrisExe>().clone();
         let firejail = self.settings.get::<FirejailExe>().clone();
+        let term = self.settings.get::<TermCommand>().clone();
         let bwrap = self.settings.get::<BubblewrapExe>().clone();
         let umu = self.settings.get::<UmuRunExe>().clone();
+        let shell = self.settings.get::<ShellExe>().clone();
         let sandbox_mode = *self.settings.get::<SandboxMode>();
         let slug = game.slug.clone();
         let name = game.name.clone();
@@ -480,7 +135,9 @@ impl App {
                 hidden,
             };
 
-            if let Err(err) = run_script(script_dir, view, &sink_builder, lua_vt).await {
+            if let Err(err) =
+                self::run_script::run_script(script_dir, view, &sink_builder, lua_vt).await
+            {
                 ::log::error!("failure when gathering/runnings scripts\n{err}");
                 return "running scripts failed".to_owned().into();
             }
@@ -547,21 +204,56 @@ impl App {
                         .stderr(stderr)
                         .status()
                 }
+
+                (Safety::SandboxShell, SandboxMode::Firejail) => {
+                    ::log::error!("shell requires sandbox mode of bubblewrap");
+                    return "only bubblewrap supported for shell".to_owned().into();
+                }
                 (Safety::Sandbox, SandboxMode::Bubblewrap) => {
-                    return umu_run(UmuCtx {
-                        name: &name,
-                        slug: &slug,
-                        bwrap: bwrap.as_path(),
-                        exe: &config.game.exe,
-                        wine_prefix: config.game.prefix.as_deref(),
-                        umu: umu.as_path(),
-                        config: &config,
-                        extra_config: extra_config.as_ref(),
-                        is_net_disabled,
-                        stdout,
-                        stderr,
-                        send_open,
-                    })
+                    return umu_run(
+                        UmuCtx {
+                            name: &name,
+                            slug: &slug,
+                            bwrap: bwrap.as_path(),
+                            shell: shell.as_path(),
+                            term: &term,
+                            exe: &config.game.exe,
+                            wine_prefix: config.game.prefix.as_deref(),
+                            umu: umu.as_path(),
+                            config: &config,
+                            extra_config: extra_config.as_ref(),
+                            is_net_disabled,
+                            stdout,
+                            stderr,
+                            send_open,
+                            runner,
+                        },
+                        false,
+                    )
+                    .await
+                    .into();
+                }
+                (Safety::SandboxShell, SandboxMode::Bubblewrap) => {
+                    return umu_run(
+                        UmuCtx {
+                            name: &name,
+                            slug: &slug,
+                            bwrap: bwrap.as_path(),
+                            shell: shell.as_path(),
+                            term: &term,
+                            exe: &config.game.exe,
+                            wine_prefix: config.game.prefix.as_deref(),
+                            umu: umu.as_path(),
+                            config: &config,
+                            extra_config: extra_config.as_ref(),
+                            is_net_disabled,
+                            stdout,
+                            stderr,
+                            send_open,
+                            runner,
+                        },
+                        true,
+                    )
                     .await
                     .into();
                 }

--- a/spel-katalog/src/run_game.rs
+++ b/spel-katalog/src/run_game.rs
@@ -377,6 +377,14 @@ async fn umu_run(ctx: UmuCtx<'_>) -> Result<String, StrError> {
             .flatten(),
     );
 
+    args.extend(
+        config
+            .system
+            .env
+            .iter()
+            .flat_map(|(key, value)| args!["--setenv", key, value]),
+    );
+
     args.extend(args!["--chdir", directory]);
 
     if let Some(_prefix) = &config.game.prefix {
@@ -436,24 +444,9 @@ impl App {
 
         let (send_open, recv_open) = oneshot_broadcast();
 
-        let to_open = *self.settings.get::<OnRun>();
-        let open_process_list = Task::future(async move {
-            match recv_open.recv_async().await {
-                Some(_) => match to_open {
-                    OnRun::Process => Some(Message::Quick(QuickMessage::OpenProcessInfo)),
-                    OnRun::Info => Some(Message::Quick(QuickMessage::OpenGameInfo)),
-                    OnRun::None => None,
-                },
-                None => {
-                    ::log::error!("could not receive open signel through oneshot");
-                    None
-                }
-            }
-        })
-        .then(|msg| msg.map_or_else(Task::none, Task::done));
-
         let lua_vt = self.lua_vt();
-        let task = Task::future(async move {
+
+        let cmd_task = Task::future(async move {
             let config = async {
                 let config = ::smol::fs::read_to_string(&configpath).await?;
                 let config = formats::Config::parse(&config)?;
@@ -585,6 +578,22 @@ impl App {
             }
         });
 
-        Task::batch([task, open_process_list])
+        let to_open = *self.settings.get::<OnRun>();
+        let open_process_list = Task::future(async move {
+            match recv_open.recv_async().await {
+                Some(_) => match to_open {
+                    OnRun::Process => Some(Message::Quick(QuickMessage::OpenProcessInfo)),
+                    OnRun::Info => Some(Message::Quick(QuickMessage::OpenGameInfo)),
+                    OnRun::None => None,
+                },
+                None => {
+                    ::log::error!("could not receive open signel through oneshot");
+                    None
+                }
+            }
+        })
+        .then(|msg| msg.map_or_else(Task::none, Task::done));
+
+        Task::batch([cmd_task, open_process_list])
     }
 }

--- a/spel-katalog/src/run_game/macros.rs
+++ b/spel-katalog/src/run_game/macros.rs
@@ -1,0 +1,26 @@
+/// Convert inputs to an array of [OsString]
+///
+/// ```
+/// assert_eq!(
+///     args!["echo", "Hello", "World!"],
+///     [OsString::from("echo"), OsString::from("Hello"), OsString::from("World!")]
+/// );
+/// ```
+macro_rules! args {
+    ($($arg:expr),* $(,)?) => {
+        [$(::std::ffi::OsString::from($arg)),*]
+    };
+}
+
+/// Create a formatted string error.
+/// ```
+/// let err = strerror!("Error occured, {}", 15);
+/// ```
+macro_rules! strerror {
+    ($($arg:tt)*) => {
+        $crate::run_game::strerror::StrError::fmt(format_args!($($arg)*))
+    };
+}
+
+pub(crate) use args;
+pub(crate) use strerror;

--- a/spel-katalog/src/run_game/run_script.rs
+++ b/spel-katalog/src/run_game/run_script.rs
@@ -133,4 +133,3 @@ pub async fn run_script(
 
     Ok(())
 }
-

--- a/spel-katalog/src/run_game/run_script.rs
+++ b/spel-katalog/src/run_game/run_script.rs
@@ -1,0 +1,136 @@
+use ::std::{path::PathBuf, sync::Arc};
+
+use ::mlua::Lua;
+use ::smol::stream::StreamExt as _;
+use ::spel_katalog_batch::BatchInfo;
+use ::spel_katalog_formats::{AdditionalConfig, Runner};
+use ::spel_katalog_sink::SinkBuilder;
+
+use crate::{
+    app::LuaVt,
+    run_game::{LuaError, ScriptGatherError},
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct BatchView<'a> {
+    pub id: i64,
+    pub slug: &'a str,
+    pub name: &'a str,
+    pub runner: &'a Runner,
+    pub config: &'a str,
+    pub extra: Option<&'a AdditionalConfig>,
+    pub hidden: bool,
+}
+
+impl From<BatchView<'_>> for BatchInfo {
+    fn from(
+        BatchView {
+            id,
+            slug,
+            name,
+            runner,
+            config,
+            extra,
+            hidden,
+        }: BatchView,
+    ) -> Self {
+        BatchInfo {
+            id,
+            slug: slug.to_owned(),
+            name: name.to_owned(),
+            runner: runner.to_string(),
+            config: config.to_owned(),
+            attrs: extra
+                .map(|extra_config| extra_config.attrs.clone())
+                .unwrap_or_default(),
+            hidden,
+        }
+    }
+}
+
+pub async fn gather_scripts(script_dir: PathBuf) -> Result<Vec<PathBuf>, ScriptGatherError> {
+    if !script_dir.exists() {
+        ::log::info!("no script dir, skipping");
+        return Ok(Vec::new());
+    }
+    let mut lua_scripts = Vec::new();
+    let mut stack = Vec::new();
+
+    stack.push(script_dir);
+
+    while let Some(dir) = stack.pop() {
+        let mut dir = ::smol::fs::read_dir(dir).await?;
+        while let Some(entry) = dir.next().await.transpose()? {
+            let ft = entry.file_type().await?;
+
+            let path = entry.path();
+
+            if ft.is_dir() {
+                stack.push(path);
+            } else if ft.is_file() {
+                if path
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("lua"))
+                {
+                    lua_scripts.push(path);
+                }
+            } else {
+                ::log::warn!("non file or directory path in script dir, {path:?}")
+            }
+        }
+    }
+
+    lua_scripts.sort_unstable();
+
+    Ok(lua_scripts)
+}
+
+pub async fn run_script(
+    script_dir: PathBuf,
+    batch_view: BatchView<'_>,
+    sink_builder: &SinkBuilder,
+    lua_vt: Arc<LuaVt>,
+) -> Result<(), ScriptGatherError> {
+    let lua_scripts = gather_scripts(script_dir).await?;
+
+    if !lua_scripts.is_empty() {
+        let batch_info = BatchInfo::from(batch_view);
+
+        let sink_builder = sink_builder.clone();
+        ::smol::unblock(move || {
+            let scripts = lua_scripts
+                .into_iter()
+                .map(|path| match ::std::fs::read_to_string(&path) {
+                    Ok(content) => Ok(content),
+                    Err(err) => Err(ScriptGatherError::ReadLuaScript(err, path)),
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let lua = Lua::new();
+            ::spel_katalog_lua::Module {
+                sink_builder: &sink_builder,
+                vt: lua_vt,
+            }
+            .register(&lua)
+            .and_then(|skeleton| {
+                let module = &skeleton.module;
+                let game = batch_info.to_lua(&lua, &skeleton.game_data)?;
+
+                module.set("game", game)?;
+
+                for script in scripts {
+                    lua.load(script).exec()?;
+                }
+
+                Ok(())
+            })
+            .map_err(|err| LuaError(err.to_string()))?;
+            Ok::<_, ScriptGatherError>(())
+        })
+        .await?;
+    }
+
+    Ok(())
+}
+

--- a/spel-katalog/src/run_game/run_umu.rs
+++ b/spel-katalog/src/run_game/run_umu.rs
@@ -13,21 +13,22 @@ use crate::{
 
 #[derive(Debug)]
 pub struct UmuCtx<'a> {
-    pub slug: &'a str,
-    pub name: &'a str,
     pub bwrap: &'a Path,
-    pub exe: &'a Path,
-    pub umu: &'a Path,
-    pub shell: &'a Path,
-    pub term: &'a str,
-    pub wine_prefix: Option<&'a Path>,
     pub config: &'a Config,
+    pub exe: &'a Path,
     pub extra_config: Option<&'a AdditionalConfig>,
     pub is_net_disabled: bool,
-    pub stdout: Stdio,
-    pub stderr: Stdio,
-    pub send_open: Sender<()>,
+    pub name: &'a str,
     pub runner: Runner,
+    pub sandbox_extras: &'a str,
+    pub send_open: Sender<()>,
+    pub shell: &'a Path,
+    pub slug: &'a str,
+    pub stderr: Stdio,
+    pub stdout: Stdio,
+    pub term: &'a str,
+    pub umu: &'a Path,
+    pub wine_prefix: Option<&'a Path>,
 }
 
 /// If possible bind user in wine prefix to steamuser in umu prefix.
@@ -50,21 +51,22 @@ fn bind_user(wine_prefix: &Path, umu_prefix: &Path) -> Option<[OsString; 3]> {
 
 pub async fn umu_run(ctx: UmuCtx<'_>, run_shell: bool) -> Result<String, StrError> {
     let UmuCtx {
-        slug,
-        name,
         bwrap,
-        exe,
-        wine_prefix,
-        umu,
         config,
+        exe,
         extra_config,
         is_net_disabled,
-        stdout,
-        stderr,
-        send_open,
+        name,
         runner,
-        term,
+        sandbox_extras,
+        send_open,
         shell,
+        slug,
+        stderr,
+        stdout,
+        term,
+        umu,
+        wine_prefix,
     } = ctx;
     let home = ::std::env::home_dir().ok_or_else(|| {
         ::log::error!("could not find user home directory");
@@ -140,6 +142,15 @@ pub async fn umu_run(ctx: UmuCtx<'_>, run_shell: bool) -> Result<String, StrErro
         "--new-session",
         "--unshare-all",
     ]);
+
+    for root in sandbox_extras
+        .split(';')
+        .filter(|s| !s.is_empty())
+        .map(Path::new)
+        .filter(|p| p.exists())
+    {
+        args.extend(args!["--ro-bind", root, root]);
+    }
 
     let additional_roots = extra_config.map_or(&[][..], |extra| extra.sandbox_root.as_slice());
 

--- a/spel-katalog/src/run_game/run_umu.rs
+++ b/spel-katalog/src/run_game/run_umu.rs
@@ -1,0 +1,224 @@
+use ::std::{ffi::OsString, path::Path, process::Stdio};
+
+use ::spel_katalog_formats::{AdditionalConfig, Runner};
+use ::spel_katalog_info::formats::Config;
+
+use crate::{
+    oneshot_broadcast::Sender,
+    run_game::{
+        macros::{args, strerror},
+        strerror::StrError,
+    },
+};
+
+#[derive(Debug)]
+pub struct UmuCtx<'a> {
+    pub slug: &'a str,
+    pub name: &'a str,
+    pub bwrap: &'a Path,
+    pub exe: &'a Path,
+    pub umu: &'a Path,
+    pub shell: &'a Path,
+    pub term: &'a str,
+    pub wine_prefix: Option<&'a Path>,
+    pub config: &'a Config,
+    pub extra_config: Option<&'a AdditionalConfig>,
+    pub is_net_disabled: bool,
+    pub stdout: Stdio,
+    pub stderr: Stdio,
+    pub send_open: Sender<()>,
+    pub runner: Runner,
+}
+
+/// If possible bind user in wine prefix to steamuser in umu prefix.
+fn bind_user(wine_prefix: &Path, umu_prefix: &Path) -> Option<[OsString; 3]> {
+    const USERS: &str = "drive_c/users";
+    let username = ::users::get_current_username()?;
+
+    let wine_home = wine_prefix.join(USERS).join(&username);
+    if !wine_home.exists() {
+        ::log::info!("user {username:?} not found in wine prefix {wine_prefix:?}");
+        return None;
+    }
+
+    let umu_home = umu_prefix.join(USERS).join("steamuser");
+
+    ::log::info!("binding {wine_home:?} to {umu_home:?}");
+
+    Some(args!["--bind", wine_home, umu_home])
+}
+
+pub async fn umu_run(ctx: UmuCtx<'_>, run_shell: bool) -> Result<String, StrError> {
+    let UmuCtx {
+        slug,
+        name,
+        bwrap,
+        exe,
+        wine_prefix,
+        umu,
+        config,
+        extra_config,
+        is_net_disabled,
+        stdout,
+        stderr,
+        send_open,
+        runner,
+        term,
+        shell,
+    } = ctx;
+    let home = ::std::env::home_dir().ok_or_else(|| {
+        ::log::error!("could not find user home directory");
+        StrError("could not find user home directory".to_owned())
+    })?;
+    let directory = exe.parent().ok_or_else(|| {
+        ::log::error!("executable {exe:?} has no parent");
+        StrError("missing executable parent".to_owned())
+    })?;
+    let xauthority = home.join(".Xauthority");
+    let umu_dir = home.join(".local/share/umu");
+    let umu_prefix = directory.join(".umu_pfx");
+
+    let mut args = Vec::<OsString>::new();
+
+    let term_command;
+    let term_path: Option<&Path>;
+    if run_shell {
+        term_command =
+            ::shell_words::split(term).map_err(|err| strerror!("could not split {term}, {err}"))?;
+        let [term, term_args @ ..] = term_command.as_slice() else {
+            return Err(strerror!("cannot get command from {term:?}"));
+        };
+        args.extend(term_args.iter().map(OsString::from));
+        args.extend(args![bwrap]);
+        term_path = Some(Path::new(term));
+    } else {
+        term_path = None;
+    }
+
+    if !umu_prefix.exists() && config.game.prefix.is_some() {
+        let status = ::smol::process::Command::new(umu)
+            .arg("")
+            .kill_on_drop(true)
+            .status()
+            .await
+            .map_err(|err| {
+                ::log::error!("could not run command to create umu prefix {umu_prefix:?}, {err}");
+                strerror!("could not create umu prefix")
+            })?;
+
+        if !status.success() {
+            ::log::error!("failed to create umu prefix {status:?}");
+            return Err(strerror!("could not create umu prefix"));
+        }
+    }
+
+    #[rustfmt::skip]
+    args.extend(args![
+        "--dev", "/dev",
+        "--proc", "/proc",
+        "--ro-bind", "/usr", "/usr",
+        "--ro-bind", "/etc", "/etc",
+        "--ro-bind", "/var", "/var",
+        "--ro-bind", "/run", "/run",
+        "--ro-bind", "/sys", "/sys",
+        "--ro-bind-try", "/opt/rocm", "/opt/rocm",
+        "--symlink", "/usr/lib", "/lib",
+        "--symlink", "/usr/lib64", "/lib64",
+        "--symlink", "/usr/lib32", "/lib32",
+        "--symlink", "/usr/bin", "/bin",
+        "--symlink", "/usr/bin", "/sbin",
+        "--tmpfs", "/home",
+        "--tmpfs", "/tmp",
+        "--ro-bind", "/tmp/.X11-unix/X0", "/tmp/.X11-unix/X0",
+        "--ro-bind", &xauthority, xauthority,
+        "--dev-bind", "/dev/dri", "/dev/dri",
+        "--bind", &umu_dir, umu_dir,
+        "--setenv", "PATH", "/usr/bin",
+        "--hostname", "games",
+        "--die-with-parent",
+        "--new-session",
+        "--unshare-all",
+    ]);
+
+    let additional_roots = extra_config.map_or(&[][..], |extra| extra.sandbox_root.as_slice());
+
+    let mut directory_bound = false;
+    if additional_roots.is_empty() {
+        let common_parent = config.game.common_parent();
+        if common_parent == directory {
+            directory_bound = true;
+        }
+        args.extend(args!["--bind", &common_parent, common_parent]);
+    } else {
+        for root in additional_roots {
+            if root == directory {
+                directory_bound = true;
+            }
+            args.extend(args!["--bind", root, root]);
+        }
+    }
+    let directory_bound = directory_bound;
+
+    if !is_net_disabled {
+        args.extend(args!["--share-net"]);
+    }
+
+    if !directory_bound {
+        args.extend(args!["--bind", &directory, directory,]);
+    }
+
+    args.extend(
+        wine_prefix
+            .and_then(|pfx| bind_user(pfx, &umu_prefix))
+            .into_iter()
+            .flatten(),
+    );
+
+    args.extend(
+        config
+            .system
+            .env
+            .iter()
+            .flat_map(|(key, value)| args!["--setenv", key, value]),
+    );
+
+    args.extend(args!["--chdir", directory]);
+
+    if let Some(_prefix) = &config.game.prefix {
+        let dir_device = umu_prefix.join("dosdevices").join("g:");
+        args.extend(args!["--symlink", "../..", dir_device]);
+        args.extend(args!["--setenv", "WINEPREFIX", umu_prefix]);
+    }
+
+    if runner.is_wine() && !run_shell {
+        args.extend(args![umu]);
+    }
+
+    if run_shell {
+        args.extend(args![shell]);
+    } else {
+        args.extend(args![exe]);
+    }
+
+    ::log::info!("running with config {args:#?}");
+
+    let cmd = ::smol::process::Command::new(if let Some(term_path) = term_path {
+        term_path
+    } else {
+        bwrap
+    })
+    .args(args)
+    .kill_on_drop(true)
+    .stdout(stdout)
+    .stderr(stderr)
+    .status();
+
+    send_open.send(());
+
+    let status = cmd.await.map_err(|err| {
+        ::log::error!("could not run {slug}\n{err}");
+        strerror!("could not run {slug}")
+    })?;
+
+    Ok(format!("{name} exited with {status}"))
+}

--- a/spel-katalog/src/run_game/run_umu.rs
+++ b/spel-katalog/src/run_game/run_umu.rs
@@ -134,6 +134,7 @@ pub async fn umu_run(ctx: UmuCtx<'_>, run_shell: bool) -> Result<String, StrErro
         "--dev-bind", "/dev/dri", "/dev/dri",
         "--bind", &umu_dir, umu_dir,
         "--setenv", "PATH", "/usr/bin",
+        "--setenv", "WINEDLLOVERRIDES", "steam_api64,version,winhttp=n,b",
         "--hostname", "games",
         "--die-with-parent",
         "--new-session",

--- a/spel-katalog/src/run_game/strerror.rs
+++ b/spel-katalog/src/run_game/strerror.rs
@@ -1,0 +1,33 @@
+use ::core::fmt::{Arguments, Display};
+
+use crate::Message;
+
+/// Error type converting error to a string.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StrError(pub String);
+
+impl StrError {
+    /// Create formatted string errror.
+    pub fn fmt(args: Arguments<'_>) -> Self {
+        Self(::std::fmt::format(args))
+    }
+}
+
+impl<E: ::core::error::Error> From<E> for StrError {
+    fn from(value: E) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl Display for StrError {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        <String as Display>::fmt(&self.0, f)
+    }
+}
+
+impl From<StrError> for Message {
+    fn from(value: StrError) -> Self {
+        value.0.into()
+    }
+}
+

--- a/spel-katalog/src/run_game/strerror.rs
+++ b/spel-katalog/src/run_game/strerror.rs
@@ -30,4 +30,3 @@ impl From<StrError> for Message {
         value.0.into()
     }
 }
-

--- a/spel-katalog/src/update.rs
+++ b/spel-katalog/src/update.rs
@@ -157,7 +157,7 @@ impl App {
             QuickMessage::Prev => return ::iced::widget::operation::focus_previous(),
             QuickMessage::RunSelected => {
                 if let Some(id) = self.games.selected() {
-                    return self.run_game(id, Safety::Firejail, false);
+                    return self.run_game(id, Safety::Sandbox, false);
                 }
             }
             QuickMessage::ToggleBatch => {
@@ -238,7 +238,7 @@ impl App {
                 return self.run_game(
                     id,
                     if sandbox {
-                        Safety::Firejail
+                        Safety::Sandbox
                     } else {
                         Safety::None
                     },
@@ -283,7 +283,7 @@ impl App {
                 self.run_game(id, Safety::from(sandbox), false)
             }
             ::spel_katalog_info::Request::RunLutrisInSandbox { id } => {
-                self.run_game(id, Safety::Firejail, true)
+                self.run_game(id, Safety::Sandbox, true)
             }
         }
     }

--- a/spel-katalog/src/update.rs
+++ b/spel-katalog/src/update.rs
@@ -282,6 +282,9 @@ impl App {
             ::spel_katalog_info::Request::RunGame { id, sandbox } => {
                 self.run_game(id, Safety::from(sandbox), false)
             }
+            ::spel_katalog_info::Request::OpenShell { id } => {
+                self.run_game(id, Safety::SandboxShell, false)
+            }
             ::spel_katalog_info::Request::RunLutrisInSandbox { id } => {
                 self.run_game(id, Safety::Sandbox, true)
             }


### PR DESCRIPTION
Games may now be ran in a bubblewrap sandbox
using umu-run

- **added bubblewrap sandboxing**
- **added todo for future**
- **moved umu prefix creation before sandbox**
- **user directory in wine prefix is now bound in umu prefix**
- **moved users to workspace**
- **added drive to game for umu prefixes**
- **added envirnment variables**
- **added button to run shell in prefix**
- **ran format**
- **added setting for extra sandbox paths**
- **updated lua stubs**
